### PR TITLE
refactor: adjust imports to package structure

### DIFF
--- a/IA/core/app.py
+++ b/IA/core/app.py
@@ -3,15 +3,15 @@ from flask import Flask, request
 from twilio.twiml.messaging_response import MessagingResponse
 import logging
 import threading
-import database
-import llm_interface
-import knowledge
-import logger_config
-from session_manager import (
-    load_session, save_session, clear_session, 
+from IA.database import database
+from IA.ai_llm import llm_interface
+from IA.knowledge import knowledge
+from IA.utils import logger_config
+from IA.core.session_manager import (
+    load_session, save_session, clear_session,
     format_product_list_for_display, format_cart_for_display
 )
-import twilio_client
+from IA.communication import twilio_client
 import os
 
 app = Flask(__name__)

--- a/IA/scripts/build_kb.py
+++ b/IA/scripts/build_kb.py
@@ -1,5 +1,5 @@
 # file: IA/build_kb.py
-import database
+from IA.database import database
 import json
 import re
 from psycopg2.extras import DictCursor

--- a/IA/scripts/discover_keywords.py
+++ b/IA/scripts/discover_keywords.py
@@ -1,5 +1,5 @@
 # file: IA/discover_keywords.py
-import database
+from IA.database import database
 import json
 import ollama
 import time


### PR DESCRIPTION
## Summary
- use fully qualified IA package imports in core app for database, LLM, knowledge, session management, utilities, and communication modules
- align build and keyword discovery scripts to import database module via IA package

## Testing
- `python -m py_compile IA/core/app.py IA/scripts/build_kb.py IA/scripts/discover_keywords.py`


------
https://chatgpt.com/codex/tasks/task_e_68962fb8c05c832c90e51c6b1c04b52f