### PR TITLE
Ensure sender_phone used for session storage

### DIFF
--- a/IA/app.py
+++ b/IA/app.py
@@ -435,7 +435,7 @@ def process_message_async(sender_phone, incoming_msg):
                 "last_bot_action": last_bot_action, "pending_action": pending_action,
                 "last_kb_search_term": last_kb_search_term
             })
-            save_session(session_id, session)
+            save_session(sender_phone, session)
             
             if response_text:
                 print(f">>> CONSOLE: Enviando resposta para o usuário: '{response_text[:80]}...'")


### PR DESCRIPTION
## Summary
- replace incorrect `session_id` reference with `sender_phone` in `process_message_async`

## Testing
- `pytest -q`
- `python -m py_compile IA/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689a19b55d60832c83d33bbd46c1390a