### PR TITLE
Add category-based fallback search for fuzzy engine

### DIFF
--- a/IA/app.py
+++ b/IA/app.py
@@ -481,18 +481,57 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
                 else:
                     # Nenhum produto encontrado - resposta inteligente
                     print(f">>> CONSOLE: Nenhum produto encontrado para '{product_name}'")
+                    category = fuzzy_engine.detect_category(product_name)
+                    if category:
+                        category_products = database.search_products_by_category_terms([category])
+                        if category_products:
+                            title = (
+                                f"📦 Não encontrei '{product_name}', mas aqui estão alguns produtos"
+                                f" da categoria '{category}':"
+                            )
+                            current_offset += len(category_products)
+                            last_shown_products.extend(category_products)
+                            response_text = format_product_list_for_display(
+                                category_products, title, len(category_products) == 5, 0
+                            )
+                            last_bot_action = "AWAITING_PRODUCT_SELECTION"
+                            add_message_to_history(
+                                session, 'assistant', response_text, 'SHOW_PRODUCTS_FROM_DB'
+                            )
+                        else:
+                            response_text = f"🤖 Não encontrei produtos para '{product_name}'."
+                            if suggestions:
+                                response_text += f"\n\n💡 {suggestions[0]}"
+                                response_text += (
+                                    "\n\nOu tente buscar por categoria: 'refrigerantes', 'detergentes', 'alimentos'."
+                                )
+                            else:
+                                response_text += (
+                                    "\n\nTente usar termos mais gerais como 'refrigerante', 'sabão' ou 'arroz'."
+                                )
 
-                    response_text = f"🤖 Não encontrei produtos para '{product_name}'."
-
-                    # Adiciona sugestões de correção
-                    if suggestions:
-                        response_text += f"\n\n💡 {suggestions[0]}"
-                        response_text += "\n\nOu tente buscar por categoria: 'refrigerantes', 'detergentes', 'alimentos'."
+                            last_bot_action = None
+                            add_message_to_history(
+                                session, 'assistant', response_text, 'NO_PRODUCTS_FOUND'
+                            )
                     else:
-                        response_text += "\n\nTente usar termos mais gerais como 'refrigerante', 'sabão' ou 'arroz'."
+                        response_text = f"🤖 Não encontrei produtos para '{product_name}'."
 
-                    last_bot_action = None
-                    add_message_to_history(session, 'assistant', response_text, 'NO_PRODUCTS_FOUND')
+                        # Adiciona sugestões de correção
+                        if suggestions:
+                            response_text += f"\n\n💡 {suggestions[0]}"
+                            response_text += (
+                                "\n\nOu tente buscar por categoria: 'refrigerantes', 'detergentes', 'alimentos'."
+                            )
+                        else:
+                            response_text += (
+                                "\n\nTente usar termos mais gerais como 'refrigerante', 'sabão' ou 'arroz'."
+                            )
+
+                        last_bot_action = None
+                        add_message_to_history(
+                            session, 'assistant', response_text, 'NO_PRODUCTS_FOUND'
+                        )
 
                 print(f">>> CONSOLE: Banco encontrou {len(products)} produtos, {len(suggestions)} sugestões")
 

--- a/IA/utils/fuzzy_search.py
+++ b/IA/utils/fuzzy_search.py
@@ -104,8 +104,38 @@ class FuzzySearchEngine:
                     new_text = text.replace(word, main_word)
                     if new_text not in variations:
                         variations.append(new_text)
-        
+
         return variations
+
+    def detect_category(self, text: str) -> Optional[str]:
+        """Detecta a categoria do produto com base nos sinônimos conhecidos.
+
+        Args:
+            text: Texto de entrada fornecido pelo usuário.
+
+        Returns:
+            O nome da categoria quando algum sinônimo é encontrado,
+            ou ``None`` caso não seja possível determinar a categoria.
+        """
+        if not text:
+            return None
+
+        normalized_text = self.normalize_text(text)
+        words = set(normalized_text.split())
+
+        for category, synonyms in self.synonyms.items():
+            normalized_category = self.normalize_text(category)
+            # Verifica se o nome da categoria aparece no texto
+            if normalized_category in words or normalized_category in normalized_text:
+                return category
+
+            # Verifica sinônimos associados
+            for synonym in synonyms:
+                normalized_syn = self.normalize_text(synonym)
+                if normalized_syn in words or normalized_syn in normalized_text:
+                    return category
+
+        return None
 
     def calculate_similarity(self, text1: str, text2: str) -> float:
         """Calcula similaridade entre dois textos (0.0 a 1.0)."""


### PR DESCRIPTION
## Summary
- extend fuzzy search engine with `detect_category` to match known synonyms and derive product category
- when product name search returns nothing, try category-based search and present alternative products

## Testing
- `python -m py_compile IA/utils/fuzzy_search.py IA/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a3c462620832cbe22e910342d9dd9