### PR TITLE
Ensure Ollama model pull completes before listing

### DIFF
--- a/IA/ai_llm/llm_interface.py
+++ b/IA/ai_llm/llm_interface.py
@@ -164,7 +164,8 @@ Instruções finais:
             if model_name not in available_models:
                 logging.error(f"[llm_interface.py] Modelo '{model_name}' não encontrado. Tentando baixar...")
                 try:
-                    client.pull(model_name)
+                    for _ in client.pull(model_name):
+                        pass  # consome o progresso para finalizar o download
                     logging.info(f"[llm_interface.py] Modelo '{model_name}' baixado com sucesso")
                     models_response = client.list()
                     if hasattr(models_response, 'get'):


### PR DESCRIPTION
## Summary
- Consume progress iterator from `client.pull` to finalize model download
- Refresh model list after pull to re-run availability checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a52506994832c97cd6391c217644c