### PR TITLE
Refatorar contexto de conversa no LLM

### DIFF
--- a/IA/app.py
+++ b/IA/app.py
@@ -11,7 +11,7 @@ from utils import logger_config
 from core.session_manager import (
     load_session, save_session, clear_session,
     format_product_list_for_display, format_cart_for_display,
-    add_message_to_history, get_conversation_context
+    add_message_to_history
 )
 from utils.quantity_extractor import extract_quantity, is_valid_quantity
 from communication import twilio_client


### PR DESCRIPTION
## Summary
- Reusar `core.session_manager.get_conversation_context` no LLM e remover função duplicada
- Ajustar montagem de prompt para utilizar contexto retornado
- Limpar `app.py` removendo import não utilizado de `get_conversation_context`

## Testing
- `python -m py_compile IA/ai_llm/llm_interface.py IA/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b3f0677c0832ca1cf9c1d0f665206