### PR TITLE
Centralize session updates to recalc stats

### DIFF
--- a/IA/core/session_manager.py
+++ b/IA/core/session_manager.py
@@ -382,26 +382,12 @@ def format_quick_actions(has_cart: bool = False, has_products: bool = False) -> 
 # ================================================================================
 
 def update_session_context(session_data: Dict, new_context: Dict):
-    """Atualiza contexto da sessão de forma inteligente."""
-    # Preserva dados importantes
-    important_keys = [
-        "customer_context", 
-        "shopping_cart", 
-        "conversation_history",
-        "last_shown_products",
-        "current_offset",
-        "last_search_type",
-        "last_search_params",
-        "pending_product_selection",
-        "pending_quantity"
-    ]
-    
-    for key in important_keys:
-        if key in new_context:
-            session_data[key] = new_context[key]
-    
+    """Atualiza dados da sessão garantindo recálculo de métricas."""
+    # Atualiza apenas os campos fornecidos, preservando os demais
+    session_data.update(new_context)
+
     # Atualiza timestamp da última atividade
     session_data["last_activity"] = datetime.now().isoformat()
-    
-    # Calcula métricas da sessão
+
+    # Recalcula estatísticas da sessão
     session_data["session_stats"] = get_session_stats(session_data)


### PR DESCRIPTION
## Summary
- replace direct session mutations with `update_session_context`
- compute session statistics on each session update

## Testing
- `python -m py_compile IA/app.py IA/core/session_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b3f86a770832ca2c7b04c2bc21259