### PR TITLE
Handle cart item removal intent

### DIFF
--- a/IA/ai_llm/llm_interface.py
+++ b/IA/ai_llm/llm_interface.py
@@ -12,6 +12,7 @@ from typing import Union, Dict
 import time
 
 from core.session_manager import get_conversation_context
+from utils.quantity_extractor import detect_quantity_modifiers
 
 # --- Configurações Globais ---
 OLLAMA_MODEL_NAME = os.getenv("OLLAMA_MODEL_NAME", "llama3.1")
@@ -31,34 +32,40 @@ AVAILABLE_TOOLS = [
     "start_new_order",
     "show_more_products",
     "report_incorrect_product",
-    "ask_continue_or_checkout"
+    "ask_continue_or_checkout",
 ]
 
 # Cache do prompt para evitar leitura repetida do arquivo
 _prompt_cache = None
 _prompt_cache_time = 0
 
+
 def load_prompt_template() -> str:
     """Carrega o prompt do arquivo de texto 'gav_prompt.txt' com cache."""
     global _prompt_cache, _prompt_cache_time
-    
+
     # Usa cache se foi carregado há menos de 5 minutos
     if _prompt_cache and (time.time() - _prompt_cache_time) < 300:
         return _prompt_cache
-    
+
     prompt_path = os.path.join("ai_llm", "gav_prompt.txt")
-    
+
     try:
         logging.info(f"[llm_interface.py] Carregando prompt de: {prompt_path}")
         with open(prompt_path, "r", encoding="utf-8") as f:
             content = f.read()
             _prompt_cache = content
             _prompt_cache_time = time.time()
-            logging.info(f"[llm_interface.py] Prompt carregado e cacheado. Tamanho: {len(content)} caracteres")
+            logging.info(
+                f"[llm_interface.py] Prompt carregado e cacheado. Tamanho: {len(content)} caracteres"
+            )
             return content
     except FileNotFoundError:
-        logging.warning(f"[llm_interface.py] Arquivo '{prompt_path}' não encontrado. Usando prompt de fallback.")
+        logging.warning(
+            f"[llm_interface.py] Arquivo '{prompt_path}' não encontrado. Usando prompt de fallback."
+        )
         return get_fallback_prompt()
+
 
 def get_fallback_prompt() -> str:
     """Prompt de emergência caso o arquivo não seja encontrado."""
@@ -70,10 +77,11 @@ FERRAMENTAS: get_top_selling_products, get_top_selling_products_by_name, add_ite
 
 SEMPRE RESPONDA EM JSON VÁLIDO COM tool_name E parameters!"""
 
+
 def extract_numeric_selection(message: str) -> Union[int, None]:
     """Extrai seleção numérica (1, 2 ou 3) da mensagem do usuário."""
     # Busca números 1, 2 ou 3 isolados na mensagem
-    numbers = re.findall(r'\b([123])\b', message.strip())
+    numbers = re.findall(r"\b([123])\b", message.strip())
     if numbers:
         try:
             return int(numbers[0])
@@ -81,41 +89,49 @@ def extract_numeric_selection(message: str) -> Union[int, None]:
             pass
     return None
 
+
 def detect_quantity_keywords(message: str) -> Union[float, None]:
     """Detecta palavras-chave de quantidade na mensagem."""
     message_lower = message.lower().strip()
-    
+
     # Mapeamento de palavras para quantidades
     quantity_map = {
-        'um': 1, 'uma': 1,
-        'dois': 2, 'duas': 2,
-        'três': 3, 'tres': 3,
-        'quatro': 4,
-        'cinco': 5,
-        'seis': 6,
-        'sete': 7,
-        'oito': 8,
-        'nove': 9,
-        'dez': 10,
-        'meia dúzia': 6, 'meia duzia': 6,
-        'uma dúzia': 12, 'uma duzia': 12,
-        'dúzia': 12, 'duzia': 12
+        "um": 1,
+        "uma": 1,
+        "dois": 2,
+        "duas": 2,
+        "três": 3,
+        "tres": 3,
+        "quatro": 4,
+        "cinco": 5,
+        "seis": 6,
+        "sete": 7,
+        "oito": 8,
+        "nove": 9,
+        "dez": 10,
+        "meia dúzia": 6,
+        "meia duzia": 6,
+        "uma dúzia": 12,
+        "uma duzia": 12,
+        "dúzia": 12,
+        "duzia": 12,
     }
-    
+
     for word, quantity in quantity_map.items():
         if word in message_lower:
             return float(quantity)
-    
+
     # Busca números decimais
-    decimal_match = re.search(r'\b(\d+(?:[.,]\d+)?)\b', message)
+    decimal_match = re.search(r"\b(\d+(?:[.,]\d+)?)\b", message)
     if decimal_match:
-        number_str = decimal_match.group(1).replace(',', '.')
+        number_str = decimal_match.group(1).replace(",", ".")
         try:
             return float(number_str)
         except ValueError:
             pass
-    
+
     return None
+
 
 def enhance_context_awareness(user_message: str, session_data: Dict) -> Dict:
     """Melhora a consciência contextual analisando estado da sessão."""
@@ -127,33 +143,33 @@ def enhance_context_awareness(user_message: str, session_data: Dict) -> Dict:
         "customer_identified": bool(session_data.get("customer_context")),
         "recent_search": session_data.get("last_kb_search_term"),
         "numeric_selection": extract_numeric_selection(user_message),
-        "inferred_quantity": detect_quantity_keywords(user_message)
+        "inferred_quantity": detect_quantity_keywords(user_message),
     }
-    
+
     # Detecta padrões específicos
     message_lower = user_message.lower().strip()
-    
+
     # Comandos diretos de carrinho
-    if any(cmd in message_lower for cmd in ['carrinho', 'ver carrinho']):
+    if any(cmd in message_lower for cmd in ["carrinho", "ver carrinho"]):
         context["direct_cart_command"] = True
-    
+
     # Comandos de finalização
-    if any(cmd in message_lower for cmd in ['finalizar', 'fechar', 'checkout']):
+    if any(cmd in message_lower for cmd in ["finalizar", "fechar", "checkout"]):
         context["direct_checkout_command"] = True
-    
+
     # Comandos de continuar compra
-    if any(cmd in message_lower for cmd in ['continuar', 'mais produtos', 'outros']):
+    if any(cmd in message_lower for cmd in ["continuar", "mais produtos", "outros"]):
         context["continue_shopping"] = True
 
     # Detecta gírias de produtos
     product_slang = {
-        'refri': 'refrigerante',
-        'zero': 'coca zero',
-        'lata': 'lata',
-        '2l': '2 litros',
-        'pet': 'garrafa pet'
+        "refri": "refrigerante",
+        "zero": "coca zero",
+        "lata": "lata",
+        "2l": "2 litros",
+        "pet": "garrafa pet",
     }
-    
+
     for slang, meaning in product_slang.items():
         if slang in message_lower:
             context["detected_slang"] = {slang: meaning}
@@ -162,8 +178,26 @@ def enhance_context_awareness(user_message: str, session_data: Dict) -> Dict:
     # Determina estágio da compra
     purchase_stage = session_data.get("purchase_stage", "greeting")
 
-    greeting_keywords = ['oi', 'olá', 'ola', 'bom dia', 'boa tarde', 'boa noite', 'e aí', 'e ai']
-    search_keywords = ['buscar', 'procurar', 'produto', 'comprar', 'preciso', 'quero', 'produtos', 'mais vendidos']
+    greeting_keywords = [
+        "oi",
+        "olá",
+        "ola",
+        "bom dia",
+        "boa tarde",
+        "boa noite",
+        "e aí",
+        "e ai",
+    ]
+    search_keywords = [
+        "buscar",
+        "procurar",
+        "produto",
+        "comprar",
+        "preciso",
+        "quero",
+        "produtos",
+        "mais vendidos",
+    ]
 
     if context.get("direct_checkout_command"):
         purchase_stage = "checkout"
@@ -171,7 +205,11 @@ def enhance_context_awareness(user_message: str, session_data: Dict) -> Dict:
         purchase_stage = "cart"
     elif any(word in message_lower for word in greeting_keywords):
         purchase_stage = "greeting"
-    elif any(word in message_lower for word in search_keywords) or context.get("has_pending_products") or context.get("recent_search"):
+    elif (
+        any(word in message_lower for word in search_keywords)
+        or context.get("has_pending_products")
+        or context.get("recent_search")
+    ):
         purchase_stage = "search"
     elif context.get("has_cart_items"):
         purchase_stage = "cart"
@@ -181,46 +219,58 @@ def enhance_context_awareness(user_message: str, session_data: Dict) -> Dict:
 
     return context
 
-def get_intent(user_message: str, session_data: Dict, customer_context: Union[Dict, None] = None, cart_items_count: int = 0) -> Dict:
+
+def get_intent(
+    user_message: str,
+    session_data: Dict,
+    customer_context: Union[Dict, None] = None,
+    cart_items_count: int = 0,
+) -> Dict:
     """
     Usa o LLM para interpretar a mensagem do usuário e traduzir em uma ferramenta.
     Com fallback rápido para mensagens simples e timeout para evitar demoras.
     """
     try:
-        logging.info(f"[llm_interface.py] Iniciando get_intent para mensagem: '{user_message}'")
-        
+        logging.info(
+            f"[llm_interface.py] Iniciando get_intent para mensagem: '{user_message}'"
+        )
+
         # Melhora consciência contextual
         enhanced_context = enhance_context_awareness(user_message, session_data)
-        
+
         # Para mensagens simples, usa detecção rápida sem IA
         message_lower = user_message.lower().strip()
         simple_patterns = [
-            r'^\s*[123]\s*$',  # Números 1, 2 ou 3
-            r'^(oi|olá|ola|e aí|e ai|boa|bom dia|boa tarde|boa noite)$',  # Saudações
-            r'^(carrinho|ver carrinho)$',  # Carrinho
-            r'^(finalizar|fechar)$',  # Checkout
-            r'^(ajuda|help)$',  # Ajuda
-            r'^(produtos|mais vendidos)$',  # Produtos populares
-            r'^(mais)$',  # Mais produtos
-            r'^(novo|nova)$'  # Novo pedido
+            r"^\s*[123]\s*$",  # Números 1, 2 ou 3
+            r"^(oi|olá|ola|e aí|e ai|boa|bom dia|boa tarde|boa noite)$",  # Saudações
+            r"^(carrinho|ver carrinho)$",  # Carrinho
+            r"^(finalizar|fechar)$",  # Checkout
+            r"^(ajuda|help)$",  # Ajuda
+            r"^(produtos|mais vendidos)$",  # Produtos populares
+            r"^(mais)$",  # Mais produtos
+            r"^(novo|nova)$",  # Novo pedido
         ]
-        
+
         for pattern in simple_patterns:
             if re.match(pattern, message_lower):
-                logging.info("[llm_interface.py] Mensagem simples detectada, usando fallback rápido")
+                logging.info(
+                    "[llm_interface.py] Mensagem simples detectada, usando fallback rápido"
+                )
                 return create_fallback_intent(user_message, enhanced_context)
-        
+
         # Se não for habilitado uso de IA ou for mensagem muito curta, usa fallback
         if not USE_AI_FALLBACK or len(user_message.strip()) < 3:
             return create_fallback_intent(user_message, enhanced_context)
-        
+
         # Carrega template do prompt
         system_prompt = load_prompt_template()
-        logging.info(f"[llm_interface.py] System prompt preparado. Tamanho: {len(system_prompt)} caracteres")
-        
+        logging.info(
+            f"[llm_interface.py] System prompt preparado. Tamanho: {len(system_prompt)} caracteres"
+        )
+
         # Obtém contexto da conversa a partir do gerenciador de sessão
         conversation_context = get_conversation_context(session_data)
-        
+
         # Informações do carrinho
         cart_info = ""
         if cart_items_count > 0:
@@ -230,25 +280,27 @@ def get_intent(user_message: str, session_data: Dict, customer_context: Union[Di
                 cart_info += " ("
                 item_names = []
                 for item in cart_items[:3]:  # Mostra apenas primeiros 3
-                    name = item.get('descricao') or item.get('canonical_name', 'Produto')
-                    qt = item.get('qt', 0)
+                    name = item.get("descricao") or item.get(
+                        "canonical_name", "Produto"
+                    )
+                    qt = item.get("qt", 0)
                     item_names.append(f"{name} x{qt}")
                 cart_info += ", ".join(item_names)
                 if len(cart_items) > 3:
                     cart_info += f" e mais {len(cart_items) - 3}"
                 cart_info += ")"
-        
+
         # Produtos disponíveis para seleção
         products_info = ""
         last_shown = session_data.get("last_shown_products", [])
         if last_shown and enhanced_context.get("numeric_selection"):
             products_info = f"PRODUTOS MOSTRADOS RECENTEMENTE: {len(last_shown)} opções disponíveis para seleção numérica"
-        
+
         # Informações do cliente
         customer_info = ""
         if customer_context:
             customer_info = f"CLIENTE: {customer_context.get('nome', 'Identificado')}"
-        
+
         # Constrói contexto completo
         full_context = f"""
 MENSAGEM DO USUÁRIO: "{user_message}"
@@ -268,18 +320,18 @@ CONTEXTO ADICIONAL:
 
 IMPORTANTE: Baseie sua resposta no contexto acima. Se há produtos mostrados e o usuário digitou um número (Ex: 1, 2 ou 3), use add_item_to_cart. Se há itens no carrinho e usuário quer finalizar, use checkout.
 """
-        
+
         # Prepara mensagens para o modelo
         messages = [
             {"role": "system", "content": system_prompt},
-            {"role": "user", "content": full_context}
+            {"role": "user", "content": full_context},
         ]
-        
+
         # Configura cliente Ollama
         client = ollama.Client(host=OLLAMA_HOST)
-        
+
         logging.info(f"[llm_interface.py] Configurando Ollama Host: '{OLLAMA_HOST}'")
-        
+
         # Tenta chamar o modelo com timeout
         start_time = time.time()
         try:
@@ -291,125 +343,166 @@ IMPORTANTE: Baseie sua resposta no contexto acima. Se há produtos mostrados e o
                     "temperature": 0.3,  # Mais determinístico
                     "top_p": 0.9,
                     "num_predict": 150,  # Limita tamanho da resposta
-                    "stop": ["\n\n", "```"]  # Para em quebras duplas ou markdown
+                    "stop": ["\n\n", "```"],  # Para em quebras duplas ou markdown
                 },
-                stream=False
+                stream=False,
             )
-            
+
             elapsed_time = time.time() - start_time
-            logging.info(f"[llm_interface.py] Resposta recebida do LLM em {elapsed_time:.2f}s")
-            
+            logging.info(
+                f"[llm_interface.py] Resposta recebida do LLM em {elapsed_time:.2f}s"
+            )
+
             # Se demorou muito, considera usar fallback na próxima
             if elapsed_time > AI_TIMEOUT:
-                logging.warning(f"[llm_interface.py] LLM demorou {elapsed_time:.2f}s (timeout: {AI_TIMEOUT}s)")
-            
+                logging.warning(
+                    f"[llm_interface.py] LLM demorou {elapsed_time:.2f}s (timeout: {AI_TIMEOUT}s)"
+                )
+
             # Extrai e processa resposta
-            content = response.get('message', {}).get('content', '')
+            content = response.get("message", {}).get("content", "")
             logging.info(f"[llm_interface.py] Resposta do LLM: {content[:200]}...")
-            
+
             cleaned_content = clean_json_response(content)
             logging.debug(f"[llm_interface.py] Conteúdo limpo: {cleaned_content}")
-            
+
             # Parse do JSON
             intent_data = json.loads(cleaned_content)
             tool_name = intent_data.get("tool_name", "handle_chitchat")
-            
+
             # Valida se a ferramenta existe
             if tool_name not in AVAILABLE_TOOLS:
                 logging.warning(f"[llm_interface.py] Ferramenta inválida: {tool_name}")
-                intent_data = {"tool_name": "handle_chitchat", "parameters": {"response_text": "Tive um problema na consulta agora. Tentar novamente?"}}
-            
+                intent_data = {
+                    "tool_name": "handle_chitchat",
+                    "parameters": {
+                        "response_text": "Tive um problema na consulta agora. Tentar novamente?"
+                    },
+                }
+
             # Enriquece parâmetros com contexto adicional
             parameters = intent_data.get("parameters", {})
-            
+
             # Se é seleção numérica e temos produtos, adiciona quantidade se detectada
-            if (tool_name == "add_item_to_cart" and 
-                enhanced_context.get("numeric_selection") and 
-                enhanced_context.get("inferred_quantity")):
-                
+            if (
+                tool_name == "add_item_to_cart"
+                and enhanced_context.get("numeric_selection")
+                and enhanced_context.get("inferred_quantity")
+            ):
+
                 if "qt" not in parameters:
                     parameters["qt"] = enhanced_context["inferred_quantity"]
-            
-            intent_data["parameters"] = validate_intent_parameters(tool_name, parameters)
-            
+
+            intent_data["parameters"] = validate_intent_parameters(
+                tool_name, parameters
+            )
+
             logging.info(f"[llm_interface.py] JSON parseado com sucesso: {intent_data}")
             return intent_data
-            
+
         except (json.JSONDecodeError, ValueError) as e:
             logging.error(f"[llm_interface.py] Erro ao parsear JSON: {e}")
             # Fallback baseado em padrões simples
             return create_fallback_intent(user_message, enhanced_context)
-        
+
         except TimeoutError:
-            logging.warning(f"[llm_interface.py] Timeout ao chamar LLM após {AI_TIMEOUT}s")
+            logging.warning(
+                f"[llm_interface.py] Timeout ao chamar LLM após {AI_TIMEOUT}s"
+            )
             return create_fallback_intent(user_message, enhanced_context)
-        
+
     except Exception as e:
         logging.error(f"[llm_interface.py] Erro geral: {e}", exc_info=True)
         # Usa fallback em caso de erro
-        return create_fallback_intent(user_message, enhance_context_awareness(user_message, session_data))
+        return create_fallback_intent(
+            user_message, enhance_context_awareness(user_message, session_data)
+        )
+
 
 def clean_json_response(content: str) -> str:
     """Limpa a resposta do LLM para extrair JSON válido."""
     # Remove markdown se presente
-    content = re.sub(r'```json\s*', '', content)
-    content = re.sub(r'```\s*', '', content)
-    
+    content = re.sub(r"```json\s*", "", content)
+    content = re.sub(r"```\s*", "", content)
+
     # Remove texto antes e depois do JSON
-    json_match = re.search(r'\{.*\}', content, re.DOTALL)
+    json_match = re.search(r"\{.*\}", content, re.DOTALL)
     if json_match:
         return json_match.group(0).strip()
-    
+
     return content.strip()
+
 
 def create_fallback_intent(user_message: str, context: Dict) -> Dict:
     """Cria intenção de fallback baseada em padrões simples quando LLM falha ou demora."""
     message_lower = user_message.lower().strip()
     stage = context.get("purchase_stage", "greeting")
-    
+
+    modifiers = detect_quantity_modifiers(message_lower)
+    if modifiers.get("action") == "remove":
+        if context.get("has_cart_items"):
+            return {"tool_name": "update_cart_item", "parameters": {"action": "remove"}}
+        return {
+            "tool_name": "handle_chitchat",
+            "parameters": {"response_text": "Seu carrinho está vazio."},
+        }
+
     # Seleção numérica direta
     if context.get("numeric_selection") and context.get("has_pending_products"):
         # Assume que o usuário quer adicionar o produto selecionado
         return {
-            "tool_name": "add_item_to_cart", 
+            "tool_name": "add_item_to_cart",
             "parameters": {
                 "codprod": 0,  # Será resolvido no app.py
-                "qt": context.get("inferred_quantity", 1)
-            }
+                "qt": context.get("inferred_quantity", 1),
+            },
         }
-    
+
     # Comandos de carrinho
     if context.get("direct_cart_command"):
         return {"tool_name": "view_cart", "parameters": {}}
-    
+
     # Comandos de checkout
     if context.get("direct_checkout_command"):
         return {"tool_name": "checkout", "parameters": {}}
-    
+
     # Continuar comprando
     if context.get("continue_shopping"):
         return {"tool_name": "get_top_selling_products", "parameters": {}}
-    
+
     # Busca de produtos (detecta palavras-chave)
-    product_keywords = ['quero', 'buscar', 'procurar', 'produto', 'comprar', 'preciso']
+    product_keywords = ["quero", "buscar", "procurar", "produto", "comprar", "preciso"]
     if any(keyword in message_lower for keyword in product_keywords):
         # Extrai nome do produto (remove palavras de comando)
         product_name = message_lower
         for keyword in product_keywords:
-            product_name = product_name.replace(keyword, '').strip()
-        
+            product_name = product_name.replace(keyword, "").strip()
+
         if product_name:
             return {
-                "tool_name": "get_top_selling_products_by_name", 
-                "parameters": {"product_name": product_name}
+                "tool_name": "get_top_selling_products_by_name",
+                "parameters": {"product_name": product_name},
             }
-    
+
     # Comandos de produtos populares
-    if any(word in message_lower for word in ['produtos', 'mais vendidos', 'populares', 'top']):
+    if any(
+        word in message_lower
+        for word in ["produtos", "mais vendidos", "populares", "top"]
+    ):
         return {"tool_name": "get_top_selling_products", "parameters": {}}
-    
+
     # Saudações
-    greetings = ['oi', 'olá', 'ola', 'boa', 'bom dia', 'boa tarde', 'boa noite', 'e aí', 'e ai']
+    greetings = [
+        "oi",
+        "olá",
+        "ola",
+        "boa",
+        "bom dia",
+        "boa tarde",
+        "boa noite",
+        "e aí",
+        "e ai",
+    ]
     if any(greeting in message_lower for greeting in greetings):
         if stage == "cart":
             response_text = "Olá! Você tem itens no carrinho. Digite 'checkout' para finalizar ou informe outro produto."
@@ -419,11 +512,11 @@ def create_fallback_intent(user_message: str, context: Dict) -> Dict:
             response_text = "Olá! Sou o G.A.V. do Comercial Esperança. Posso mostrar nossos produtos mais vendidos ou você já sabe o que procura?"
         return {
             "tool_name": "handle_chitchat",
-            "parameters": {"response_text": response_text}
+            "parameters": {"response_text": response_text},
         }
-    
+
     # Ajuda
-    if any(word in message_lower for word in ['ajuda', 'help', 'como', 'funciona']):
+    if any(word in message_lower for word in ["ajuda", "help", "como", "funciona"]):
         if stage == "cart":
             response_text = "Você pode digitar 'checkout' para finalizar ou informar outro produto para continuar comprando."
         elif stage == "checkout":
@@ -432,24 +525,27 @@ def create_fallback_intent(user_message: str, context: Dict) -> Dict:
             response_text = "Como posso ajudar? Digite o nome de um produto para buscar, 'carrinho' para ver suas compras, ou 'produtos' para ver os mais vendidos."
         return {
             "tool_name": "handle_chitchat",
-            "parameters": {"response_text": response_text}
+            "parameters": {"response_text": response_text},
         }
-    
+
     # Novo pedido
-    if 'novo' in message_lower or 'nova' in message_lower:
+    if "novo" in message_lower or "nova" in message_lower:
         return {"tool_name": "start_new_order", "parameters": {}}
-    
+
     # Comando "mais" para ver mais produtos
-    if 'mais' in message_lower and context.get("last_action") == "AWAITING_PRODUCT_SELECTION":
+    if (
+        "mais" in message_lower
+        and context.get("last_action") == "AWAITING_PRODUCT_SELECTION"
+    ):
         return {"tool_name": "show_more_products", "parameters": {}}
-    
+
     # Fallback padrão - tenta buscar o termo completo
     if len(message_lower) > 2:
         return {
             "tool_name": "get_top_selling_products_by_name",
-            "parameters": {"product_name": message_lower}
+            "parameters": {"product_name": message_lower},
         }
-    
+
     if stage == "cart":
         default_text = "Não entendi. Você pode digitar o nome de um produto para adicionar mais itens ou 'checkout' para finalizar."
     elif stage == "checkout":
@@ -460,12 +556,13 @@ def create_fallback_intent(user_message: str, context: Dict) -> Dict:
         default_text = "Não entendi. Posso mostrar os produtos mais vendidos ou buscar algo específico."
     return {
         "tool_name": "handle_chitchat",
-        "parameters": {"response_text": default_text}
+        "parameters": {"response_text": default_text},
     }
+
 
 def validate_intent_parameters(tool_name: str, parameters: Dict) -> Dict:
     """Valida e corrige parâmetros da intenção conforme a ferramenta."""
-    
+
     if tool_name == "add_item_to_cart":
         # Garante que codprod seja inteiro e qt seja número válido
         if "codprod" in parameters:
@@ -473,7 +570,7 @@ def validate_intent_parameters(tool_name: str, parameters: Dict) -> Dict:
                 parameters["codprod"] = int(parameters["codprod"])
             except (ValueError, TypeError):
                 parameters["codprod"] = 0
-        
+
         if "qt" in parameters:
             try:
                 qt = float(parameters["qt"])
@@ -482,48 +579,55 @@ def validate_intent_parameters(tool_name: str, parameters: Dict) -> Dict:
                 parameters["qt"] = qt
             except (ValueError, TypeError):
                 parameters["qt"] = 1
-    
+
     elif tool_name == "get_top_selling_products_by_name":
         # Garante que product_name seja string não vazia
         if "product_name" not in parameters or not parameters["product_name"]:
             parameters["product_name"] = "produto"
-        
+
         # Limita tamanho do nome do produto
         parameters["product_name"] = str(parameters["product_name"])[:100]
-    
+
     elif tool_name == "update_cart_item":
         # Valida ação e parâmetros relacionados
         valid_actions = ["remove", "update_quantity", "add_quantity"]
         if "action" not in parameters or parameters["action"] not in valid_actions:
             parameters["action"] = "remove"
-    
+
     return parameters
 
-def get_enhanced_intent(user_message: str, session_data: Dict, customer_context: Union[Dict, None] = None) -> Dict:
+
+def get_enhanced_intent(
+    user_message: str, session_data: Dict, customer_context: Union[Dict, None] = None
+) -> Dict:
     """Versão melhorada da função get_intent com validação adicional."""
-    
+
     # Obtém intenção básica
-    intent = get_intent(user_message, session_data, customer_context, len(session_data.get("shopping_cart", [])))
-    
+    intent = get_intent(
+        user_message,
+        session_data,
+        customer_context,
+        len(session_data.get("shopping_cart", [])),
+    )
+
     if not intent:
-        return create_fallback_intent(user_message, enhance_context_awareness(user_message, session_data))
-    
+        return create_fallback_intent(
+            user_message, enhance_context_awareness(user_message, session_data)
+        )
+
     # Valida e corrige parâmetros
     tool_name = intent.get("tool_name", "handle_chitchat")
     parameters = intent.get("parameters", {})
-    
+
     validated_parameters = validate_intent_parameters(tool_name, parameters)
-    
-    return {
-        "tool_name": tool_name,
-        "parameters": validated_parameters
-    }
-    
+
+    return {"tool_name": tool_name, "parameters": validated_parameters}
+
+
 def get_intent_fast(user_message: str, session_data: Dict) -> Dict:
     """Versão rápida de detecção de intenção sem usar IA."""
     # Melhora consciência contextual
     context = enhance_context_awareness(user_message, session_data)
-    
+
     # Retorna intenção baseada em padrões
     return create_fallback_intent(user_message, context)
-    

--- a/IA/app.py
+++ b/IA/app.py
@@ -9,10 +9,16 @@ from ai_llm import llm_interface
 from knowledge import knowledge
 from utils import logger_config
 from core.session_manager import (
-    load_session, save_session, clear_session,
-    format_product_list_for_display, format_cart_for_display,
-    add_message_to_history, get_conversation_context,
-    format_quick_actions, update_session_context,detect_user_intent_type
+    load_session,
+    save_session,
+    clear_session,
+    format_product_list_for_display,
+    format_cart_for_display,
+    add_message_to_history,
+    get_conversation_context,
+    format_quick_actions,
+    update_session_context,
+    detect_user_intent_type,
 )
 from utils.quantity_extractor import extract_quantity, is_valid_quantity
 from communication import twilio_client
@@ -23,81 +29,91 @@ from knowledge.knowledge import find_product_in_kb_with_analysis
 app = Flask(__name__)
 logger_config.setup_logger()
 
+
 def get_product_name(product: Dict) -> str:
     """Extrai o nome do produto, compatível com produtos do banco (descricao) e da KB (canonical_name)."""
-    return product.get('descricao') or product.get('canonical_name', 'Produto sem nome')
+    return product.get("descricao") or product.get("canonical_name", "Produto sem nome")
 
-def find_products_in_cart_by_name(cart: List[Dict], product_name: str) -> List[Tuple[int, Dict]]:
+
+def find_products_in_cart_by_name(
+    cart: List[Dict], product_name: str
+) -> List[Tuple[int, Dict]]:
     """
     Encontra produtos no carrinho pelo nome (busca fuzzy).
-    
+
     Returns:
         Lista de tuplas (índice, produto) que correspondem ao nome
     """
     if not cart or not product_name:
         return []
-    
+
     # Importa aqui para evitar imports circulares
     from utils.fuzzy_search import fuzzy_engine
-    
+
     matches = []
     search_term = product_name.lower().strip()
-    
+
     for i, item in enumerate(cart):
         item_name = get_product_name(item).lower()
-        
+
         # Busca exata
         if search_term in item_name or item_name in search_term:
             matches.append((i, item))
             continue
-            
+
         # Busca fuzzy
         similarity = fuzzy_engine.calculate_similarity(search_term, item_name)
         if similarity >= 0.6:  # Threshold para considerar uma correspondência
             matches.append((i, item))
-    
+
     return matches
+
 
 def format_cart_with_indices(cart: List[Dict]) -> str:
     """Formata o carrinho com índices para facilitar seleção."""
     if not cart:
         return "🤖 Seu carrinho de compras está vazio."
-    
+
     response = "🛒 Seu Carrinho de Compras:\n"
     total = 0.0
-    
+
     for i, item in enumerate(cart, 1):
-        price = item.get('pvenda') or 0.0
-        qt = item.get('qt', 0)
+        price = item.get("pvenda") or 0.0
+        qt = item.get("qt", 0)
         subtotal = price * qt
         total += subtotal
-        
-        price_str = f"R$ {price:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
-        subtotal_str = f"R$ {subtotal:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+
+        price_str = (
+            f"R$ {price:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+        )
+        subtotal_str = (
+            f"R$ {subtotal:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+        )
         product_name = get_product_name(item)
-        
+
         response += f"{i}. {product_name} (Qtd: {qt}) - Unit: {price_str} - Subtotal: {subtotal_str}\n"
-    
+
     total_str = f"R$ {total:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
     response += f"-----------------------------------\nTOTAL DO PEDIDO: {total_str}"
     return response
 
+
 def remove_item_from_cart(cart: List[Dict], index: int) -> Tuple[bool, str, List[Dict]]:
     """
     Remove item do carrinho pelo índice.
-    
+
     Returns:
         Tupla (sucesso, mensagem, novo_carrinho)
     """
     if not cart:
         return False, "🤖 Seu carrinho está vazio.", cart
-    
+
     if not (1 <= index <= len(cart)):
         return False, f"🤖 Número inválido. Escolha entre 1 e {len(cart)}.", cart
-    
+
     removed_item = cart.pop(index - 1)
     product_name = get_product_name(removed_item)
-    
+
     if cart:
         cart_display = format_cart_for_display(cart)
         message = f"🗑️ {product_name} removido do carrinho.\n\n{cart_display}"
@@ -109,37 +125,40 @@ def remove_item_from_cart(cart: List[Dict], index: int) -> Tuple[bool, str, List
 
     return True, message, cart
 
-def add_quantity_to_cart_item(cart: List[Dict], index: int, additional_qty: Union[int, float]) -> Tuple[bool, str, List[Dict]]:
+
+def add_quantity_to_cart_item(
+    cart: List[Dict], index: int, additional_qty: Union[int, float]
+) -> Tuple[bool, str, List[Dict]]:
     """
     Adiciona quantidade a um item específico do carrinho.
-    
+
     Returns:
         Tupla (sucesso, mensagem, novo_carrinho)
     """
     if not cart:
         return False, "🤖 Seu carrinho está vazio.", cart
-    
+
     if not (1 <= index <= len(cart)):
         return False, f"🤖 Número inválido. Escolha entre 1 e {len(cart)}.", cart
-    
+
     if not is_valid_quantity(additional_qty):
         return False, f"🤖 Quantidade inválida: {additional_qty}", cart
-    
-    cart[index - 1]['qt'] += additional_qty
+
+    cart[index - 1]["qt"] += additional_qty
     product_name = get_product_name(cart[index - 1])
-    new_total = cart[index - 1]['qt']
-    
+    new_total = cart[index - 1]["qt"]
+
     # Formata a quantidade para exibição
     if isinstance(additional_qty, float):
-        qty_display = f"{additional_qty:.1f}".rstrip('0').rstrip('.')
+        qty_display = f"{additional_qty:.1f}".rstrip("0").rstrip(".")
     else:
         qty_display = str(additional_qty)
-    
+
     if isinstance(new_total, float):
-        total_display = f"{new_total:.1f}".rstrip('0').rstrip('.')
+        total_display = f"{new_total:.1f}".rstrip("0").rstrip(".")
     else:
         total_display = str(new_total)
-    
+
     cart_display = format_cart_for_display(cart)
     message = f"✅ Adicionei +{qty_display} {product_name}. Total agora: {total_display}\n\n{cart_display}"
 
@@ -148,31 +167,34 @@ def add_quantity_to_cart_item(cart: List[Dict], index: int, additional_qty: Unio
 
     return True, message, cart
 
-def update_cart_item_quantity(cart: List[Dict], index: int, new_qty: Union[int, float]) -> Tuple[bool, str, List[Dict]]:
+
+def update_cart_item_quantity(
+    cart: List[Dict], index: int, new_qty: Union[int, float]
+) -> Tuple[bool, str, List[Dict]]:
     """
     Atualiza a quantidade de um item do carrinho.
-    
+
     Returns:
         Tupla (sucesso, mensagem, novo_carrinho)
     """
     if not cart:
         return False, "🤖 Seu carrinho está vazio.", cart
-    
+
     if not (1 <= index <= len(cart)):
         return False, f"🤖 Número inválido. Escolha entre 1 e {len(cart)}.", cart
-    
+
     if not is_valid_quantity(new_qty):
         return False, f"🤖 Quantidade inválida: {new_qty}", cart
-    
-    cart[index - 1]['qt'] = new_qty
+
+    cart[index - 1]["qt"] = new_qty
     product_name = get_product_name(cart[index - 1])
-    
+
     # Formata a quantidade para exibição
     if isinstance(new_qty, float):
-        qty_display = f"{new_qty:.1f}".rstrip('0').rstrip('.')
+        qty_display = f"{new_qty:.1f}".rstrip("0").rstrip(".")
     else:
         qty_display = str(new_qty)
-    
+
     cart_display = format_cart_for_display(cart)
     message = f"✅ Quantidade de {product_name} atualizada para {qty_display}\n\n{cart_display}"
 
@@ -181,54 +203,53 @@ def update_cart_item_quantity(cart: List[Dict], index: int, new_qty: Union[int, 
 
     return True, message, cart
 
+
 def generate_continue_or_checkout_message(cart: List[Dict]) -> str:
     """Gera uma mensagem amigável perguntando se o cliente deseja continuar ou finalizar."""
     quick_actions = format_quick_actions(has_cart=bool(cart))
-    return (
-        "🛍️ Deseja continuar comprando ou finalizar o pedido?\n\n"
-        f"{quick_actions}"
-    )
+    return "🛍️ Deseja continuar comprando ou finalizar o pedido?\n\n" f"{quick_actions}"
+
 
 def suggest_alternatives(failed_search_term: str) -> str:
     """Gera sugestões quando uma busca falha completamente."""
-    
+
     # Importa aqui para evitar imports circulares
     from utils.fuzzy_search import fuzzy_engine
-    
+
     suggestions = []
-    
+
     # Aplica correções automáticas
     corrected = fuzzy_engine.apply_corrections(failed_search_term)
     if corrected != failed_search_term:
         suggestions.append(f"Tente: '{corrected}'")
-    
+
     # Expande com sinônimos
     expansions = fuzzy_engine.expand_with_synonyms(failed_search_term)
     for expansion in expansions[:2]:
         if expansion != failed_search_term:
             suggestions.append(f"Ou tente: '{expansion}'")
-    
+
     # Sugestões gerais baseadas na palavra
     words = failed_search_term.lower().split()
     general_suggestions = []
-    
+
     for word in words:
-        if any(x in word for x in ['coca', 'refri', 'soda']):
+        if any(x in word for x in ["coca", "refri", "soda"]):
             general_suggestions.append("refrigerantes")
-        elif any(x in word for x in ['sabao', 'deterg', 'limp']):
+        elif any(x in word for x in ["sabao", "deterg", "limp"]):
             general_suggestions.append("produtos de limpeza")
-        elif any(x in word for x in ['cafe', 'acu', 'arroz', 'feij']):
+        elif any(x in word for x in ["cafe", "acu", "arroz", "feij"]):
             general_suggestions.append("alimentos básicos")
-    
+
     if general_suggestions:
         suggestions.extend([f"Categoria: {s}" for s in general_suggestions[:2]])
-    
+
     if not suggestions:
         suggestions = [
             "Tente termos mais simples",
-            "Use nomes de categoria: 'refrigerante', 'sabão', 'arroz'"
+            "Use nomes de categoria: 'refrigerante', 'sabão', 'arroz'",
         ]
-    
+
     return " • ".join(suggestions[:3])
 
 
@@ -247,27 +268,33 @@ def _extract_state(session: Dict) -> Dict:
     }
 
 
-def _handle_pending_action(session: Dict, state: Dict, incoming_msg: str) -> Tuple[Union[Dict, None], str]:
+def _handle_pending_action(
+    session: Dict, state: Dict, incoming_msg: str
+) -> Tuple[Union[Dict, None], str]:
     """Processa ações pendentes existentes na sessão."""
     pending_action = state.get("pending_action")
     shopping_cart = state.get("shopping_cart", [])
     intent = None
     response_text = ""
 
-    if pending_action == 'AWAITING_QUANTITY':
+    if pending_action == "AWAITING_QUANTITY":
         print(">>> CONSOLE: Tratando ação pendente AWAITING_QUANTITY")
 
         # 🆕 Extrai quantidade usando linguagem natural
         qt = extract_quantity(incoming_msg)
 
         if qt is not None and is_valid_quantity(qt):
-            product_to_add = session.get('pending_product_for_cart')
+            product_to_add = session.get("pending_product_for_cart")
             if product_to_add:
                 term_to_learn = session.get("term_to_learn_after_quantity")
                 if term_to_learn:
-                    print(f">>> CONSOLE: Aprendendo que '{term_to_learn}' se refere a '{get_product_name(product_to_add)}'...")
+                    print(
+                        f">>> CONSOLE: Aprendendo que '{term_to_learn}' se refere a '{get_product_name(product_to_add)}'..."
+                    )
                     knowledge.update_kb(term_to_learn, product_to_add)
-                    update_session_context(session, {"term_to_learn_after_quantity": None})
+                    update_session_context(
+                        session, {"term_to_learn_after_quantity": None}
+                    )
 
                 # Converte para int se for número inteiro
                 if isinstance(qt, float) and qt.is_integer():
@@ -277,20 +304,23 @@ def _handle_pending_action(session: Dict, state: Dict, incoming_msg: str) -> Tup
                 duplicate_index = None
                 for i, item in enumerate(shopping_cart):
                     if (
-                        product_to_add.get('codprod')
-                        and item.get('codprod') == product_to_add.get('codprod')
+                        product_to_add.get("codprod")
+                        and item.get("codprod") == product_to_add.get("codprod")
                     ) or (
-                        not product_to_add.get('codprod')
-                        and get_product_name(item).lower() == get_product_name(product_to_add).lower()
+                        not product_to_add.get("codprod")
+                        and get_product_name(item).lower()
+                        == get_product_name(product_to_add).lower()
                     ):
                         duplicate_index = i
                         break
 
                 if duplicate_index is not None:
                     existing_item = shopping_cart[duplicate_index]
-                    existing_qty = existing_item.get('qt', 0)
+                    existing_qty = existing_item.get("qt", 0)
                     if isinstance(existing_qty, float):
-                        existing_qty_display = f"{existing_qty:.1f}".rstrip('0').rstrip('.')
+                        existing_qty_display = f"{existing_qty:.1f}".rstrip("0").rstrip(
+                            "."
+                        )
                     else:
                         existing_qty_display = str(existing_qty)
                     product_name = get_product_name(existing_item)
@@ -312,18 +342,18 @@ def _handle_pending_action(session: Dict, state: Dict, incoming_msg: str) -> Tup
 
                     add_message_to_history(
                         session,
-                        'assistant',
+                        "assistant",
                         response_text,
-                        'REQUEST_DUPLICATE_DECISION',
+                        "REQUEST_DUPLICATE_DECISION",
                     )
 
-                    pending_action = 'AWAITING_DUPLICATE_DECISION'
+                    pending_action = "AWAITING_DUPLICATE_DECISION"
                 else:
                     shopping_cart.append({**product_to_add, "qt": qt})
 
                     # 🆕 Resposta mais natural baseada na entrada
                     if isinstance(qt, float):
-                        qt_display = f"{qt:.1f}".rstrip('0').rstrip('.')
+                        qt_display = f"{qt:.1f}".rstrip("0").rstrip(".")
                     else:
                         qt_display = str(qt)
 
@@ -335,7 +365,9 @@ def _handle_pending_action(session: Dict, state: Dict, incoming_msg: str) -> Tup
                     )
 
                     # 📝 REGISTRA A RESPOSTA DO BOT
-                    add_message_to_history(session, 'assistant', response_text, 'ADD_TO_CART')
+                    add_message_to_history(
+                        session, "assistant", response_text, "ADD_TO_CART"
+                    )
 
                     update_session_context(
                         session,
@@ -348,7 +380,7 @@ def _handle_pending_action(session: Dict, state: Dict, incoming_msg: str) -> Tup
 
             else:
                 response_text = "🤖 Ocorreu um erro. Não sei qual produto adicionar."
-                add_message_to_history(session, 'assistant', response_text, 'ERROR')
+                add_message_to_history(session, "assistant", response_text, "ERROR")
                 update_session_context(
                     session,
                     {
@@ -371,101 +403,129 @@ Qual quantidade você quer?"""
             else:
                 response_text = f"🤖 A quantidade {qt} parece muito alta. Por favor, digite uma quantidade entre 1 e 1000."
 
-            add_message_to_history(session, 'assistant', response_text, 'REQUEST_QUANTITY')
+            add_message_to_history(
+                session, "assistant", response_text, "REQUEST_QUANTITY"
+            )
             pending_action = None
 
-        state['pending_action'] = pending_action
-        state['shopping_cart'] = shopping_cart
+        state["pending_action"] = pending_action
+        state["shopping_cart"] = shopping_cart
 
-    elif pending_action == 'AWAITING_CART_ITEM_SELECTION':
+    elif pending_action == "AWAITING_CART_ITEM_SELECTION":
         # Usuário está selecionando item do carrinho após ambiguidade
-        cart_action = session.get('pending_cart_action')
-        cart_matches = session.get('pending_cart_matches', [])
+        cart_action = session.get("pending_cart_action")
+        cart_matches = session.get("pending_cart_matches", [])
 
         if incoming_msg.isdigit():
             selection = int(incoming_msg)
 
             # Verifica se a seleção é válida
-            valid_indices = [match[0] + 1 for match in cart_matches]  # +1 para índice baseado em 1
+            valid_indices = [
+                match[0] + 1 for match in cart_matches
+            ]  # +1 para índice baseado em 1
 
             if selection in valid_indices:
-                if cart_action == 'remove':
-                    success, message, shopping_cart = remove_item_from_cart(shopping_cart, selection)
+                if cart_action == "remove":
+                    success, message, shopping_cart = remove_item_from_cart(
+                        shopping_cart, selection
+                    )
                     response_text = message
-                    add_message_to_history(session, 'assistant', response_text, 'REMOVE_FROM_CART')
-                elif cart_action == 'add':
-                    quantity = session.get('pending_cart_quantity', 1)
-                    success, message, shopping_cart = add_quantity_to_cart_item(shopping_cart, selection, quantity)
+                    add_message_to_history(
+                        session, "assistant", response_text, "REMOVE_FROM_CART"
+                    )
+                elif cart_action == "add":
+                    quantity = session.get("pending_cart_quantity", 1)
+                    success, message, shopping_cart = add_quantity_to_cart_item(
+                        shopping_cart, selection, quantity
+                    )
                     response_text = message
-                    add_message_to_history(session, 'assistant', response_text, 'ADD_QUANTITY_TO_CART')
-                elif cart_action == 'update':
-                    quantity = session.get('pending_cart_quantity', 1)
-                    success, message, shopping_cart = update_cart_item_quantity(shopping_cart, selection, quantity)
+                    add_message_to_history(
+                        session, "assistant", response_text, "ADD_QUANTITY_TO_CART"
+                    )
+                elif cart_action == "update":
+                    quantity = session.get("pending_cart_quantity", 1)
+                    success, message, shopping_cart = update_cart_item_quantity(
+                        shopping_cart, selection, quantity
+                    )
                     response_text = message
-                    add_message_to_history(session, 'assistant', response_text, 'UPDATE_CART_ITEM')
+                    add_message_to_history(
+                        session, "assistant", response_text, "UPDATE_CART_ITEM"
+                    )
                 else:
                     response_text = "🤖 Ação inválida."
-                    add_message_to_history(session, 'assistant', response_text, 'ERROR')
+                    add_message_to_history(session, "assistant", response_text, "ERROR")
 
                 # Limpa estado pendente
                 pending_action = None
-                session.pop('pending_cart_action', None)
-                session.pop('pending_cart_matches', None)
-                session.pop('pending_cart_quantity', None)
+                session.pop("pending_cart_action", None)
+                session.pop("pending_cart_matches", None)
+                session.pop("pending_cart_quantity", None)
             else:
                 response_text = (
                     f"🤖 Número inválido. Escolha um dos números listados: {', '.join(map(str, valid_indices))}\n\n"
                     f"{format_quick_actions(has_cart=bool(shopping_cart), has_products=True)}"
                 )
-                add_message_to_history(session, 'assistant', response_text, 'REQUEST_CLARIFICATION')
+                add_message_to_history(
+                    session, "assistant", response_text, "REQUEST_CLARIFICATION"
+                )
         else:
             response_text = (
                 "🤖 Por favor, digite o número do item que você quer selecionar.\n\n"
                 f"{format_quick_actions(has_cart=bool(shopping_cart), has_products=True)}"
             )
-            add_message_to_history(session, 'assistant', response_text, 'REQUEST_CLARIFICATION')
+            add_message_to_history(
+                session, "assistant", response_text, "REQUEST_CLARIFICATION"
+            )
 
-        state['pending_action'] = pending_action
-        state['shopping_cart'] = shopping_cart
+        state["pending_action"] = pending_action
+        state["shopping_cart"] = shopping_cart
 
-    elif pending_action == 'AWAITING_DUPLICATE_DECISION':
+    elif pending_action == "AWAITING_DUPLICATE_DECISION":
         print(">>> CONSOLE: Tratando ação pendente AWAITING_DUPLICATE_DECISION")
         choice = incoming_msg.strip()
-        index = session.get('duplicate_item_index')
-        qty = session.get('duplicate_item_qty')
+        index = session.get("duplicate_item_index")
+        qty = session.get("duplicate_item_qty")
 
-        if choice == '1':
-            success, message, shopping_cart = add_quantity_to_cart_item(shopping_cart, index, qty)
+        if choice == "1":
+            success, message, shopping_cart = add_quantity_to_cart_item(
+                shopping_cart, index, qty
+            )
             response_text = message
-            add_message_to_history(session, 'assistant', response_text, 'ADD_QUANTITY_TO_CART')
+            add_message_to_history(
+                session, "assistant", response_text, "ADD_QUANTITY_TO_CART"
+            )
             pending_action = None
             update_session_context(
                 session,
                 {
-                    'duplicate_item_index': None,
-                    'duplicate_item_qty': None,
-                    'pending_action': None,
+                    "duplicate_item_index": None,
+                    "duplicate_item_qty": None,
+                    "pending_action": None,
                 },
             )
-        elif choice == '2':
-            success, message, shopping_cart = update_cart_item_quantity(shopping_cart, index, qty)
+        elif choice == "2":
+            success, message, shopping_cart = update_cart_item_quantity(
+                shopping_cart, index, qty
+            )
             response_text = message
-            add_message_to_history(session, 'assistant', response_text, 'UPDATE_CART_ITEM_QUANTITY')
+            add_message_to_history(
+                session, "assistant", response_text, "UPDATE_CART_ITEM_QUANTITY"
+            )
             pending_action = None
             update_session_context(
                 session,
                 {
-                    'duplicate_item_index': None,
-                    'duplicate_item_qty': None,
-                    'pending_action': None,
+                    "duplicate_item_index": None,
+                    "duplicate_item_qty": None,
+                    "pending_action": None,
                 },
             )
         else:
             if index and 1 <= index <= len(shopping_cart):
                 existing_item = shopping_cart[index - 1]
-                existing_qty = existing_item.get('qt', 0)
+                existing_qty = existing_item.get("qt", 0)
                 if isinstance(existing_qty, float):
-                    existing_qty_display = f"{existing_qty:.1f}".rstrip('0').rstrip('.')
+                    existing_qty_display = f"{existing_qty:.1f}".rstrip("0").rstrip(".")
                 else:
                     existing_qty_display = str(existing_qty)
                 product_name = get_product_name(existing_item)
@@ -474,17 +534,25 @@ Qual quantidade você quer?"""
                     "Deseja *1* somar ou *2* substituir pela nova quantidade?"
                 )
             else:
-                response_text = (
-                    "Por favor, responda com *1* para somar ou *2* substituir pela nova quantidade."
-                )
-            add_message_to_history(session, 'assistant', response_text, 'REQUEST_DUPLICATE_DECISION')
+                response_text = "Por favor, responda com *1* para somar ou *2* substituir pela nova quantidade."
+            add_message_to_history(
+                session, "assistant", response_text, "REQUEST_DUPLICATE_DECISION"
+            )
 
-        state['pending_action'] = pending_action
-        state['shopping_cart'] = shopping_cart
+        state["pending_action"] = pending_action
+        state["shopping_cart"] = shopping_cart
 
     elif pending_action:
         print(f">>> CONSOLE: Tratando ação pendente {pending_action}")
-        affirmative_responses = ["sim", "pode ser", "s", "claro", "quero", "ok", "beleza"]
+        affirmative_responses = [
+            "sim",
+            "pode ser",
+            "s",
+            "claro",
+            "quero",
+            "ok",
+            "beleza",
+        ]
         negative_responses = ["não", "n", "agora não", "deixa"]
         if incoming_msg.lower() in affirmative_responses:
             if pending_action == "show_top_selling":
@@ -495,19 +563,21 @@ Qual quantidade você quer?"""
                 "🤖 Tudo bem! O que você gostaria de fazer então?\n\n"
                 f"{format_quick_actions(has_cart=bool(shopping_cart))}"
             )
-            add_message_to_history(session, 'assistant', response_text, 'CHITCHAT')
+            add_message_to_history(session, "assistant", response_text, "CHITCHAT")
             pending_action = None
-            state['last_shown_products'] = []
-            state['last_bot_action'] = 'AWAITING_MENU_SELECTION'
+            state["last_shown_products"] = []
+            state["last_bot_action"] = "AWAITING_MENU_SELECTION"
         else:
             pending_action = None
 
-        state['pending_action'] = pending_action
+        state["pending_action"] = pending_action
 
     return intent, response_text
 
 
-def _process_user_message(session: Dict, state: Dict, incoming_msg: str) -> Tuple[Union[Dict, None], str]:
+def _process_user_message(
+    session: Dict, state: Dict, incoming_msg: str
+) -> Tuple[Union[Dict, None], str]:
     """Processa a mensagem do usuário e determina a intenção."""
     intent = None
     response_text = ""
@@ -520,15 +590,17 @@ def _process_user_message(session: Dict, state: Dict, incoming_msg: str) -> Tupl
                 "🤖 Não entendi. Quer selecionar um dos produtos da lista? Se sim, me diga o número.\n\n"
                 f"{format_quick_actions(has_cart=bool(shopping_cart), has_products=True)}"
             )
-            state['last_bot_action'] = 'AWAITING_PRODUCT_SELECTION'
+            state["last_bot_action"] = "AWAITING_PRODUCT_SELECTION"
         else:
             response_text = (
                 "🤖 Por favor, me diga o que você precisa.\n\n"
                 f"{format_quick_actions(has_cart=bool(shopping_cart))}"
             )
-            state['last_shown_products'] = []
-            state['last_bot_action'] = 'AWAITING_MENU_SELECTION'
-        add_message_to_history(session, 'assistant', response_text, 'REQUEST_CLARIFICATION')
+            state["last_shown_products"] = []
+            state["last_bot_action"] = "AWAITING_MENU_SELECTION"
+        add_message_to_history(
+            session, "assistant", response_text, "REQUEST_CLARIFICATION"
+        )
         return intent, response_text
 
     intent_type = detect_user_intent_type(incoming_msg, session)
@@ -537,9 +609,18 @@ def _process_user_message(session: Dict, state: Dict, incoming_msg: str) -> Tupl
         intent = {"tool_name": "view_cart", "parameters": {}}
     elif intent_type == "CHECKOUT":
         intent = {"tool_name": "checkout", "parameters": {}}
-    elif intent_type == "NUMERIC_SELECTION" and last_bot_action in ["AWAITING_PRODUCT_SELECTION", "AWAITING_CORRECTION_SELECTION"]:
-        intent = {"tool_name": "add_item_to_cart", "parameters": {"index": int(incoming_msg)}}
-    elif intent_type == "NUMERIC_SELECTION" and last_bot_action == "AWAITING_MENU_SELECTION":
+    elif intent_type == "NUMERIC_SELECTION" and last_bot_action in [
+        "AWAITING_PRODUCT_SELECTION",
+        "AWAITING_CORRECTION_SELECTION",
+    ]:
+        intent = {
+            "tool_name": "add_item_to_cart",
+            "parameters": {"index": int(incoming_msg)},
+        }
+    elif (
+        intent_type == "NUMERIC_SELECTION"
+        and last_bot_action == "AWAITING_MENU_SELECTION"
+    ):
         if incoming_msg == "1":
             intent = {"tool_name": "get_top_selling_products", "parameters": {}}
         elif incoming_msg == "2":
@@ -551,9 +632,11 @@ def _process_user_message(session: Dict, state: Dict, incoming_msg: str) -> Tupl
                 "🤖 Opção inválida. Escolha 1, 2 ou 3.\n\n"
                 f"{format_quick_actions(has_cart=bool(shopping_cart))}"
             )
-            add_message_to_history(session, 'assistant', response_text, 'REQUEST_CLARIFICATION')
-            state['last_shown_products'] = []
-            state['last_bot_action'] = 'AWAITING_MENU_SELECTION'
+            add_message_to_history(
+                session, "assistant", response_text, "REQUEST_CLARIFICATION"
+            )
+            state["last_shown_products"] = []
+            state["last_bot_action"] = "AWAITING_MENU_SELECTION"
             return intent, response_text
     elif incoming_msg.lower() in ["mais", "proximo", "próximo", "mais produtos"]:
         intent = {"tool_name": "show_more_products", "parameters": {}}
@@ -563,15 +646,17 @@ def _process_user_message(session: Dict, state: Dict, incoming_msg: str) -> Tupl
             user_message=incoming_msg,
             session_data=session,
             customer_context=state.get("customer_context"),
-            cart_items_count=len(shopping_cart)
+            cart_items_count=len(shopping_cart),
         )
         print(f">>> CONSOLE: IA retornou a intenção: {intent}")
     elif intent_type == "GREETING":
         response_text = "🤖 Olá! Como posso ajudar você hoje?"
-        add_message_to_history(session, 'assistant', response_text, 'GREETING')
+        add_message_to_history(session, "assistant", response_text, "GREETING")
     else:
         response_text = "🤖 Desculpe, não entendi. Pode reformular?"
-        add_message_to_history(session, 'assistant', response_text, 'REQUEST_CLARIFICATION')
+        add_message_to_history(
+            session, "assistant", response_text, "REQUEST_CLARIFICATION"
+        )
 
     return intent, response_text
 
@@ -622,24 +707,32 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
                 quality_emoji = "⚡" if kb_analysis["quality"] == "excellent" else "🎯"
                 title = f"{quality_emoji} Encontrei isto para '{product_name}' (busca rápida):"
 
-                response_text = format_product_list_for_display(last_shown_products, title, False, 0)
+                response_text = format_product_list_for_display(
+                    last_shown_products, title, False, 0
+                )
                 last_bot_action = "AWAITING_PRODUCT_SELECTION"
-                add_message_to_history(session, 'assistant', response_text, 'SHOW_PRODUCTS_FROM_KB')
+                add_message_to_history(
+                    session, "assistant", response_text, "SHOW_PRODUCTS_FROM_KB"
+                )
 
-                print(f">>> CONSOLE: KB encontrou {len(last_shown_products)} produtos (qualidade: {kb_analysis['quality']})")
+                print(
+                    f">>> CONSOLE: KB encontrou {len(last_shown_products)} produtos (qualidade: {kb_analysis['quality']})"
+                )
 
             else:
                 # Knowledge Base não encontrou ou qualidade baixa - busca no banco com fuzzy
-                print(f">>> CONSOLE: KB qualidade baixa ({kb_analysis.get('quality', 'none')}), buscando no banco...")
+                print(
+                    f">>> CONSOLE: KB qualidade baixa ({kb_analysis.get('quality', 'none')}), buscando no banco..."
+                )
 
                 current_offset, last_shown_products = 0, []
-                last_search_type, last_search_params = "by_name", {'product_name': product_name}
+                last_search_type, last_search_params = "by_name", {
+                    "product_name": product_name
+                }
 
                 # 🆕 USA BUSCA FUZZY COM SUGESTÕES
                 search_result = search_products_with_suggestions(
-                    product_name,
-                    limit=5,
-                    offset=current_offset
+                    product_name, limit=5, offset=current_offset
                 )
 
                 products = search_result["products"]
@@ -658,18 +751,24 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
                         title_emoji = "📦"
 
                     title = f"{title_emoji} Encontrei estes produtos relacionados a '{product_name}':"
-                    response_text = format_product_list_for_display(products, title, len(products) == 5, 0)
+                    response_text = format_product_list_for_display(
+                        products, title, len(products) == 5, 0
+                    )
 
                     # 🆕 ADICIONA SUGESTÕES SE HOUVER
                     if suggestions:
                         response_text += f"\n💡 Dica: {suggestions[0]}"
 
                     last_bot_action = "AWAITING_PRODUCT_SELECTION"
-                    add_message_to_history(session, 'assistant', response_text, 'SHOW_PRODUCTS_FROM_DB')
+                    add_message_to_history(
+                        session, "assistant", response_text, "SHOW_PRODUCTS_FROM_DB"
+                    )
 
                 else:
                     # Nenhum produto encontrado - resposta inteligente
-                    print(f">>> CONSOLE: Nenhum produto encontrado para '{product_name}'")
+                    print(
+                        f">>> CONSOLE: Nenhum produto encontrado para '{product_name}'"
+                    )
 
                     response_text = f"🤖 Não encontrei produtos para '{product_name}'."
 
@@ -681,9 +780,13 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
                         response_text += "\n\nTente usar termos mais gerais como 'refrigerante', 'sabão' ou 'arroz'."
 
                     last_bot_action = None
-                    add_message_to_history(session, 'assistant', response_text, 'NO_PRODUCTS_FOUND')
+                    add_message_to_history(
+                        session, "assistant", response_text, "NO_PRODUCTS_FOUND"
+                    )
 
-                print(f">>> CONSOLE: Banco encontrou {len(products)} produtos, {len(suggestions)} sugestões")
+                print(
+                    f">>> CONSOLE: Banco encontrou {len(products)} produtos, {len(suggestions)} sugestões"
+                )
 
         else:  # get_top_selling_products
             current_offset, last_shown_products = 0, []
@@ -692,9 +795,13 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
             title = "⭐ Estes são nossos produtos mais populares:"
             current_offset += 5
             last_shown_products.extend(products)
-            response_text = format_product_list_for_display(products, title, len(products) == 5, 0)
+            response_text = format_product_list_for_display(
+                products, title, len(products) == 5, 0
+            )
             last_bot_action = "AWAITING_PRODUCT_SELECTION"
-            add_message_to_history(session, 'assistant', response_text, 'SHOW_TOP_PRODUCTS')
+            add_message_to_history(
+                session, "assistant", response_text, "SHOW_TOP_PRODUCTS"
+            )
 
     elif tool_name == "add_item_to_cart":
         product_to_add = None
@@ -723,29 +830,39 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
         if product_to_add:
             term_to_learn = None
             is_correction = last_bot_action == "AWAITING_CORRECTION_SELECTION"
-            is_new_learning = last_bot_action == "AWAITING_PRODUCT_SELECTION" and last_search_type == "by_name"
+            is_new_learning = (
+                last_bot_action == "AWAITING_PRODUCT_SELECTION"
+                and last_search_type == "by_name"
+            )
 
             if is_correction:
                 term_to_learn = last_kb_search_term
             elif is_new_learning:
                 term_to_learn = last_search_params.get("product_name")
 
-            update_session_context(session, {
-                'pending_product_for_cart': product_to_add,
-                'term_to_learn_after_quantity': term_to_learn,
-                'pending_action': 'AWAITING_QUANTITY'
-            })
-            pending_action = 'AWAITING_QUANTITY'
+            update_session_context(
+                session,
+                {
+                    "pending_product_for_cart": product_to_add,
+                    "term_to_learn_after_quantity": term_to_learn,
+                    "pending_action": "AWAITING_QUANTITY",
+                },
+            )
+            pending_action = "AWAITING_QUANTITY"
 
             response_text = f"Quantas unidades de {get_product_name(product_to_add)} você deseja adicionar?"
-            add_message_to_history(session, 'assistant', response_text, 'REQUEST_QUANTITY')
+            add_message_to_history(
+                session, "assistant", response_text, "REQUEST_QUANTITY"
+            )
 
         else:
             response_text = (
                 "🤖 Produto não encontrado. Você pode tentar buscar novamente?\n\n"
                 f"{format_quick_actions(has_cart=bool(shopping_cart))}"
             )
-            add_message_to_history(session, 'assistant', response_text, 'PRODUCT_NOT_FOUND')
+            add_message_to_history(
+                session, "assistant", response_text, "PRODUCT_NOT_FOUND"
+            )
 
     elif tool_name == "update_cart_item":
         action = parameters.get("action")
@@ -758,6 +875,46 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
         index = parameters.get("index")
         product_name = parameters.get("product_name")
         matched_index = None
+
+        if action == "remove" and not index and not product_name:
+            if shopping_cart:
+                matches = list(enumerate(shopping_cart))
+                pending_action = "AWAITING_CART_ITEM_SELECTION"
+                update_session_context(
+                    session,
+                    {
+                        "pending_cart_matches": matches,
+                        "pending_cart_action": "remove",
+                        "pending_cart_quantity": quantity,
+                        "pending_action": pending_action,
+                    },
+                )
+                response_text = f"{format_cart_with_indices(shopping_cart)}\n\nDigite o número do item que deseja remover."
+                add_message_to_history(
+                    session, "assistant", response_text, "REQUEST_CART_ITEM_SELECTION"
+                )
+            else:
+                pending_action = None
+                response_text = "🤖 Seu carrinho está vazio."
+                add_message_to_history(
+                    session, "assistant", response_text, "CART_EMPTY"
+                )
+                state.update(
+                    {
+                        "customer_context": customer_context,
+                        "shopping_cart": shopping_cart,
+                        "last_search_type": last_search_type,
+                        "last_search_params": last_search_params,
+                        "current_offset": current_offset,
+                        "last_shown_products": last_shown_products,
+                        "last_bot_action": "AWAITING_MENU_SELECTION",
+                        "pending_action": pending_action,
+                        "last_kb_search_term": last_kb_search_term,
+                    }
+                )
+                return response_text
+
+            last_bot_action = "AWAITING_MENU_SELECTION"
 
         if index:
             try:
@@ -772,49 +929,77 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
                 matched_index = matches[0][0] + 1
             elif len(matches) > 1:
                 pending_action = "AWAITING_CART_ITEM_SELECTION"
-                pending_cart_action = 'remove' if action == 'remove' else ('add' if action == 'add_quantity' else 'update')
-                update_session_context(session, {
-                    'pending_cart_matches': matches,
-                    'pending_cart_action': pending_cart_action,
-                    'pending_cart_quantity': quantity,
-                    'pending_action': pending_action
-                })
+                pending_cart_action = (
+                    "remove"
+                    if action == "remove"
+                    else ("add" if action == "add_quantity" else "update")
+                )
+                update_session_context(
+                    session,
+                    {
+                        "pending_cart_matches": matches,
+                        "pending_cart_action": pending_cart_action,
+                        "pending_cart_quantity": quantity,
+                        "pending_action": pending_action,
+                    },
+                )
                 options = "\n".join(
-                    [f"{idx+1}. {get_product_name(item)} (Qtd: {item.get('qt', 0)})" for idx, item in matches]
+                    [
+                        f"{idx+1}. {get_product_name(item)} (Qtd: {item.get('qt', 0)})"
+                        for idx, item in matches
+                    ]
                 )
-                response_text = (
-                    f"🤖 Encontrei vários itens com esse nome no carrinho:\n{options}\nDigite o número do item desejado."
+                response_text = f"🤖 Encontrei vários itens com esse nome no carrinho:\n{options}\nDigite o número do item desejado."
+                add_message_to_history(
+                    session, "assistant", response_text, "REQUEST_CART_ITEM_SELECTION"
                 )
-                add_message_to_history(session, 'assistant', response_text, 'REQUEST_CART_ITEM_SELECTION')
 
         if matched_index is not None:
             if action == "remove":
-                success, response_text, shopping_cart = remove_item_from_cart(shopping_cart, matched_index)
-                add_message_to_history(session, 'assistant', response_text, 'REMOVE_FROM_CART')
+                success, response_text, shopping_cart = remove_item_from_cart(
+                    shopping_cart, matched_index
+                )
+                add_message_to_history(
+                    session, "assistant", response_text, "REMOVE_FROM_CART"
+                )
             elif action == "add_quantity":
-                success, response_text, shopping_cart = add_quantity_to_cart_item(shopping_cart, matched_index, quantity)
-                add_message_to_history(session, 'assistant', response_text, 'ADD_QUANTITY_TO_CART')
+                success, response_text, shopping_cart = add_quantity_to_cart_item(
+                    shopping_cart, matched_index, quantity
+                )
+                add_message_to_history(
+                    session, "assistant", response_text, "ADD_QUANTITY_TO_CART"
+                )
             elif action == "update_quantity":
-                success, response_text, shopping_cart = update_cart_item_quantity(shopping_cart, matched_index, quantity)
-                add_message_to_history(session, 'assistant', response_text, 'UPDATE_CART_ITEM')
+                success, response_text, shopping_cart = update_cart_item_quantity(
+                    shopping_cart, matched_index, quantity
+                )
+                add_message_to_history(
+                    session, "assistant", response_text, "UPDATE_CART_ITEM"
+                )
             else:
                 response_text = "🤖 Ação inválida."
-                add_message_to_history(session, 'assistant', response_text, 'ERROR')
-            last_bot_action = 'AWAITING_MENU_SELECTION'
+                add_message_to_history(session, "assistant", response_text, "ERROR")
+            last_bot_action = "AWAITING_MENU_SELECTION"
             pending_action = None
         elif pending_action != "AWAITING_CART_ITEM_SELECTION":
             response_text = (
                 f"🤖 Não encontrei esse item no carrinho.\n\n{format_cart_for_display(shopping_cart)}\n\n"
                 f"{format_quick_actions(has_cart=bool(shopping_cart))}"
             )
-            add_message_to_history(session, 'assistant', response_text, 'CART_ITEM_NOT_FOUND')
-            last_bot_action = 'AWAITING_MENU_SELECTION'
+            add_message_to_history(
+                session, "assistant", response_text, "CART_ITEM_NOT_FOUND"
+            )
+            last_bot_action = "AWAITING_MENU_SELECTION"
             pending_action = None
 
     elif tool_name == "show_more_products":
         if not last_search_type:
-            response_text = "🤖 Para eu mostrar mais, primeiro você precisa fazer uma busca."
-            add_message_to_history(session, 'assistant', response_text, 'NO_PREVIOUS_SEARCH')
+            response_text = (
+                "🤖 Para eu mostrar mais, primeiro você precisa fazer uma busca."
+            )
+            add_message_to_history(
+                session, "assistant", response_text, "NO_PREVIOUS_SEARCH"
+            )
         else:
             offset_before_call = current_offset
             products = []
@@ -824,7 +1009,9 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
                 title = "Mostrando mais produtos populares:"
             elif last_search_type == "by_name":
                 product_name = last_search_params.get("product_name", "")
-                products = database.get_top_selling_products_by_name(product_name, offset=current_offset)
+                products = database.get_top_selling_products_by_name(
+                    product_name, offset=current_offset
+                )
                 title = f"Mostrando mais produtos relacionados a '{product_name}':"
 
             if not products:
@@ -832,54 +1019,71 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
                     "🤖 Não encontrei mais produtos para essa busca.\n\n"
                     f"{format_quick_actions(has_cart=bool(shopping_cart))}"
                 )
-                add_message_to_history(session, 'assistant', response_text, 'NO_MORE_PRODUCTS')
+                add_message_to_history(
+                    session, "assistant", response_text, "NO_MORE_PRODUCTS"
+                )
             else:
                 current_offset += 5
                 last_shown_products.extend(products)
-                response_text = format_product_list_for_display(products, title, len(products) == 5, offset=offset_before_call)
+                response_text = format_product_list_for_display(
+                    products, title, len(products) == 5, offset=offset_before_call
+                )
                 last_bot_action = "AWAITING_PRODUCT_SELECTION"
-                add_message_to_history(session, 'assistant', response_text, 'SHOW_MORE_PRODUCTS')
+                add_message_to_history(
+                    session, "assistant", response_text, "SHOW_MORE_PRODUCTS"
+                )
 
-    elif tool_name == 'view_cart':
+    elif tool_name == "view_cart":
         response_text = (
             f"{format_cart_for_display(shopping_cart)}\n\n"
             f"{format_quick_actions(has_cart=bool(shopping_cart))}"
         )
-        add_message_to_history(session, 'assistant', response_text, 'SHOW_CART')
+        add_message_to_history(session, "assistant", response_text, "SHOW_CART")
         last_shown_products = []
-        last_bot_action = 'AWAITING_MENU_SELECTION'
+        last_bot_action = "AWAITING_MENU_SELECTION"
 
-    elif tool_name == 'start_new_order':
-        customer_context, shopping_cart, last_shown_products, last_search_type, last_search_params, current_offset, last_kb_search_term = None, [], [], None, {}, 0, None
+    elif tool_name == "start_new_order":
+        (
+            customer_context,
+            shopping_cart,
+            last_shown_products,
+            last_search_type,
+            last_search_params,
+            current_offset,
+            last_kb_search_term,
+        ) = (None, [], [], None, {}, 0, None)
         pending_action = None
         last_bot_action = None
         clear_session(sender_phone)
         session.clear()
 
-        update_session_context(session, {
-            'shopping_cart': shopping_cart,
-            'pending_action': pending_action,
-            'last_bot_action': last_bot_action
-        })
+        update_session_context(
+            session,
+            {
+                "shopping_cart": shopping_cart,
+                "pending_action": pending_action,
+                "last_bot_action": last_bot_action,
+            },
+        )
         response_text = (
             "🧹 Certo! Carrinho e dados limpos. Vamos começar de novo!\n\n"
             f"{format_quick_actions(has_cart=False)}"
         )
 
-        add_message_to_history(session, 'assistant', response_text, 'NEW_ORDER')
+        add_message_to_history(session, "assistant", response_text, "NEW_ORDER")
 
-    elif tool_name == 'checkout':
+    elif tool_name == "checkout":
         if not shopping_cart:
             response_text = (
                 "🤖 Seu carrinho está vazio!\n\n"
                 f"{format_quick_actions(has_cart=False)}"
             )
-            add_message_to_history(session, 'assistant', response_text, 'EMPTY_CART')
+            add_message_to_history(session, "assistant", response_text, "EMPTY_CART")
             last_shown_products = []
-            last_bot_action = 'AWAITING_MENU_SELECTION'
+            last_bot_action = "AWAITING_MENU_SELECTION"
         elif not customer_context:
             response_text = "⭐ Para finalizar a compra, preciso do seu CNPJ."
-            add_message_to_history(session, 'assistant', response_text, 'REQUEST_CNPJ')
+            add_message_to_history(session, "assistant", response_text, "REQUEST_CNPJ")
             last_shown_products = []
             last_bot_action = None
         else:
@@ -888,11 +1092,13 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
                 f"{format_cart_for_display(shopping_cart)}\n(Funcionalidade de inserção do pedido no sistema será implementada futuramente)\n\n"
                 f"{format_quick_actions(has_cart=bool(shopping_cart))}"
             )
-            add_message_to_history(session, 'assistant', response_text, 'CHECKOUT_READY')
+            add_message_to_history(
+                session, "assistant", response_text, "CHECKOUT_READY"
+            )
             last_shown_products = []
-            last_bot_action = 'AWAITING_MENU_SELECTION'
+            last_bot_action = "AWAITING_MENU_SELECTION"
 
-    elif tool_name == 'find_customer_by_cnpj':
+    elif tool_name == "find_customer_by_cnpj":
         cnpj = parameters.get("cnpj")
         if cnpj:
             customer = database.find_customer_by_cnpj(cnpj)
@@ -902,87 +1108,103 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str) -> 
                     f"🤖 Olá, {customer_context['nome']}! Bem-vindo(a) de volta.\n\n"
                     f"{format_quick_actions(has_cart=bool(shopping_cart))}"
                 )
-                add_message_to_history(session, 'assistant', response_text, 'CUSTOMER_IDENTIFIED')
+                add_message_to_history(
+                    session, "assistant", response_text, "CUSTOMER_IDENTIFIED"
+                )
                 last_shown_products = []
-                last_bot_action = 'AWAITING_MENU_SELECTION'
+                last_bot_action = "AWAITING_MENU_SELECTION"
             else:
                 response_text = f"🤖 Não encontrei um cliente com o CNPJ {cnpj}."
-            add_message_to_history(session, 'assistant', response_text, 'CUSTOMER_NOT_FOUND')
+            add_message_to_history(
+                session, "assistant", response_text, "CUSTOMER_NOT_FOUND"
+            )
         else:
             response_text = "🤖 Por favor, informe seu CNPJ."
-            add_message_to_history(session, 'assistant', response_text, 'REQUEST_CNPJ')
+            add_message_to_history(session, "assistant", response_text, "REQUEST_CNPJ")
 
-    elif tool_name == 'ask_continue_or_checkout':
+    elif tool_name == "ask_continue_or_checkout":
         if shopping_cart:
             response_text = generate_continue_or_checkout_message(shopping_cart)
-            add_message_to_history(session, 'assistant', response_text, 'ASK_CONTINUE_OR_CHECKOUT')
+            add_message_to_history(
+                session, "assistant", response_text, "ASK_CONTINUE_OR_CHECKOUT"
+            )
         else:
             response_text = (
                 "🤖 Seu carrinho está vazio. Que tal começar adicionando um produto?\n\n"
                 f"{format_quick_actions(has_cart=False)}"
             )
-            add_message_to_history(session, 'assistant', response_text, 'EMPTY_CART')
+            add_message_to_history(session, "assistant", response_text, "EMPTY_CART")
         last_shown_products = []
-        last_bot_action = 'AWAITING_MENU_SELECTION'
+        last_bot_action = "AWAITING_MENU_SELECTION"
 
-    elif tool_name == 'handle_chitchat':
+    elif tool_name == "handle_chitchat":
         response_text = (
             f"{parameters.get('response_text', 'Entendi!')}\n\n"
             f"{format_quick_actions(has_cart=bool(shopping_cart))}"
         )
-        add_message_to_history(session, 'assistant', response_text, 'CHITCHAT')
+        add_message_to_history(session, "assistant", response_text, "CHITCHAT")
         last_shown_products = []
-        last_bot_action = 'AWAITING_MENU_SELECTION'
+        last_bot_action = "AWAITING_MENU_SELECTION"
 
     elif not tool_name and "response_text" in intent:
         response_text = (
             f"{intent['response_text']}\n\n"
             f"{format_quick_actions(has_cart=bool(shopping_cart))}"
         )
-        add_message_to_history(session, 'assistant', response_text, 'GENERIC_RESPONSE')
+        add_message_to_history(session, "assistant", response_text, "GENERIC_RESPONSE")
         last_shown_products = []
-        last_bot_action = 'AWAITING_MENU_SELECTION'
+        last_bot_action = "AWAITING_MENU_SELECTION"
 
     else:
         logging.warning(f"Fallback Final: Ferramenta desconhecida '{tool_name}'")
         response_text = "🤖 Hum, não entendi muito bem. Que tal começarmos pelos produtos mais vendidos? Posso te mostrar?"
         pending_action = "show_top_selling"
-        add_message_to_history(session, 'assistant', response_text, 'FALLBACK')
+        add_message_to_history(session, "assistant", response_text, "FALLBACK")
 
-    state.update({
-        "customer_context": customer_context,
-        "shopping_cart": shopping_cart,
-        "last_search_type": last_search_type,
-        "last_search_params": last_search_params,
-        "current_offset": current_offset,
-        "last_shown_products": last_shown_products,
-        "last_bot_action": last_bot_action,
-        "pending_action": pending_action,
-        "last_kb_search_term": last_kb_search_term,
-    })
+    state.update(
+        {
+            "customer_context": customer_context,
+            "shopping_cart": shopping_cart,
+            "last_search_type": last_search_type,
+            "last_search_params": last_search_params,
+            "current_offset": current_offset,
+            "last_shown_products": last_shown_products,
+            "last_bot_action": last_bot_action,
+            "pending_action": pending_action,
+            "last_kb_search_term": last_kb_search_term,
+        }
+    )
 
     return response_text
 
 
-def _finalize_session(sender_phone: str, session: Dict, state: Dict, response_text: str) -> None:
+def _finalize_session(
+    sender_phone: str, session: Dict, state: Dict, response_text: str
+) -> None:
     """Atualiza e persiste a sessão, além de enviar a resposta ao usuário."""
-    update_session_context(session, {
-        "customer_context": state.get("customer_context"),
-        "shopping_cart": state.get("shopping_cart", []),
-        "last_search_type": state.get("last_search_type"),
-        "last_search_params": state.get("last_search_params", {}),
-        "current_offset": state.get("current_offset", 0),
-        "last_shown_products": state.get("last_shown_products", []),
-        "last_bot_action": state.get("last_bot_action"),
-        "pending_action": state.get("pending_action"),
-        "last_kb_search_term": state.get("last_kb_search_term"),
-    })
+    update_session_context(
+        session,
+        {
+            "customer_context": state.get("customer_context"),
+            "shopping_cart": state.get("shopping_cart", []),
+            "last_search_type": state.get("last_search_type"),
+            "last_search_params": state.get("last_search_params", {}),
+            "current_offset": state.get("current_offset", 0),
+            "last_shown_products": state.get("last_shown_products", []),
+            "last_bot_action": state.get("last_bot_action"),
+            "pending_action": state.get("pending_action"),
+            "last_kb_search_term": state.get("last_kb_search_term"),
+        },
+    )
     save_session(sender_phone, session)
 
     if response_text:
-        print(f">>> CONSOLE: Enviando resposta para o usuário: '{response_text[:80]}...'")
+        print(
+            f">>> CONSOLE: Enviando resposta para o usuário: '{response_text[:80]}...'"
+        )
         twilio_client.send_whatsapp_message(to=sender_phone, body=response_text)
-                
+
+
 def process_message_async(sender_phone: str, incoming_msg: str):
     """
     Esta função faz todo o trabalho pesado em segundo plano (thread) para não causar timeout.
@@ -994,7 +1216,7 @@ def process_message_async(sender_phone: str, incoming_msg: str):
             session = load_session(sender_phone)
 
             # 📝 REGISTRA A MENSAGEM DO USUÁRIO NO HISTÓRICO
-            add_message_to_history(session, 'user', incoming_msg)
+            add_message_to_history(session, "user", incoming_msg)
 
             # Carrega estado atual da sessão
             state = _extract_state(session)
@@ -1004,19 +1226,23 @@ def process_message_async(sender_phone: str, incoming_msg: str):
 
             # 2. Se não houve resposta ou intenção, determina a intenção
             if not intent and not response_text:
-                intent, response_text = _process_user_message(session, state, incoming_msg)
+                intent, response_text = _process_user_message(
+                    session, state, incoming_msg
+                )
 
             # 3. Executa a intenção identificada
             if intent and not response_text:
                 response_text = _route_tool(session, state, intent, sender_phone)
 
             # 4. Mensagem padrão caso nenhuma resposta seja definida
-            if not response_text and not state.get('pending_action'):
+            if not response_text and not state.get("pending_action"):
                 response_text = (
                     "Operação concluída. O que mais posso fazer por você?\n\n"
                     f"{format_quick_actions(has_cart=bool(state.get('shopping_cart', [])))}"
                 )
-                add_message_to_history(session, 'assistant', response_text, 'OPERATION_COMPLETE')
+                add_message_to_history(
+                    session, "assistant", response_text, "OPERATION_COMPLETE"
+                )
 
             # 5. Atualiza e persiste a sessão, enviando a resposta
             _finalize_session(sender_phone, session, state, response_text)
@@ -1033,18 +1259,22 @@ def process_message_async(sender_phone: str, incoming_msg: str):
             # Registra o erro no histórico também
             try:
                 session = load_session(sender_phone)
-                add_message_to_history(session, 'assistant', error_response, 'ERROR')
+                add_message_to_history(session, "assistant", error_response, "ERROR")
                 save_session(sender_phone, session)
             except:
                 pass  # Se falhar aqui, apenas ignora para não causar loop de erro
 
-@app.route("/webhook", methods=['POST'])
+
+@app.route("/webhook", methods=["POST"])
 def webhook():
-    incoming_msg = request.values.get('Body', '').strip()
-    sender_phone = request.values.get('From', '')
-    thread = threading.Thread(target=process_message_async, args=(sender_phone, incoming_msg))
+    incoming_msg = request.values.get("Body", "").strip()
+    sender_phone = request.values.get("From", "")
+    thread = threading.Thread(
+        target=process_message_async, args=(sender_phone, incoming_msg)
+    )
     thread.start()
     return "", 200
 
+
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=8080, debug=True)
+    app.run(host="0.0.0.0", port=8080, debug=True)


### PR DESCRIPTION
## Summary
- Detect removal requests using quantity modifiers and handle empty cart responses
- Route cart removal requests without specific item by displaying indexed cart and prompting for item number

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b5960b608832ca0fd04919c757a7a