### PR TITLE
Store quantity in pending product selection

### DIFF
--- a/IA/app.py
+++ b/IA/app.py
@@ -226,6 +226,8 @@ def _process_user_message(session: Dict, state: Dict, incoming_msg: str) -> Tupl
     quantity = extract_quantity(incoming_msg, last_shown)
     if not is_valid_quantity(quantity):
         quantity = 1
+    pending_selection = state.get("pending_product_selection") or {}
+    stored_quantity = pending_selection.get("quantity") if isinstance(pending_selection, dict) else None
 
     # Detecção imediata de comandos de limpeza do carrinho
     if detect_cart_clear_commands(incoming_msg):
@@ -255,6 +257,13 @@ def _process_user_message(session: Dict, state: Dict, incoming_msg: str) -> Tupl
             logging.info(f"[PROCESS] CNPJ detectado: {cnpj_match.group()}")
             return intent, response_text
     
+    # Quantidade informada sem produto definido
+    if intent_type == "QUANTITY_SPECIFICATION" and is_valid_quantity(quantity):
+        pending_selection.setdefault("quantity", quantity)
+        state["pending_product_selection"] = pending_selection
+        response_text = "Entendi! Agora me diga o número do produto desejado."
+        return intent, response_text
+
     # Seleção numérica
     if intent_type == "NUMERIC_SELECTION":
         last_shown = state.get("last_shown_products", [])
@@ -264,7 +273,9 @@ def _process_user_message(session: Dict, state: Dict, incoming_msg: str) -> Tupl
                 selection = int(selection_text.split()[0]) - 1
                 if 0 <= selection < len(last_shown):
                     product = last_shown[selection]
-                    qt = quantity if (not selection_text.isdigit() and is_valid_quantity(quantity)) else 1
+                    qt = quantity if (not selection_text.isdigit() and is_valid_quantity(quantity)) else (
+                        stored_quantity if is_valid_quantity(stored_quantity) else 1
+                    )
                     intent = {
                         "tool_name": "add_item_to_cart",
                         "parameters": {
@@ -272,6 +283,7 @@ def _process_user_message(session: Dict, state: Dict, incoming_msg: str) -> Tupl
                             "qt": qt
                         }
                     }
+                    state["pending_product_selection"] = None
                     logging.info(f"[PROCESS] Seleção numérica: produto {selection+1} - qtd {qt}")
                     return intent, response_text
             except ValueError:

--- a/IA/core/session_manager.py
+++ b/IA/core/session_manager.py
@@ -58,6 +58,7 @@ def load_session(sender_phone: str) -> Dict:
         "last_shown_products": [],
         "last_bot_action": None,
         "pending_action": None,
+        "pending_product_selection": None,
         "last_kb_search_term": None,
         "conversation_history": [],
         "conversation_summary": "",
@@ -359,7 +360,7 @@ def get_session_stats(session_data: Dict) -> Dict:
         "customer_identified": bool(session_data.get("customer_context")),
         "last_action": session_data.get("last_bot_action", "NONE"),
         "has_pending_selection": bool(session_data.get("last_shown_products")),
-        "has_pending_quantity": bool(session_data.get("pending_product_selection")),
+        "has_pending_quantity": bool((session_data.get("pending_product_selection") or {}).get("quantity")),
         "purchase_stage": session_data.get("purchase_stage", "greeting")
     }
     
@@ -482,6 +483,7 @@ def validate_and_correct_session(session_data: Dict) -> Dict:
         "last_shown_products": [],
         "last_bot_action": None,
         "pending_action": None,
+        "pending_product_selection": None,
         "last_kb_search_term": None,
         "conversation_history": [],
         "conversation_summary": "",
@@ -501,5 +503,12 @@ def validate_and_correct_session(session_data: Dict) -> Dict:
     
     if not isinstance(session_data.get("last_shown_products"), list):
         session_data["last_shown_products"] = []
-    
+
+    pps = session_data.get("pending_product_selection")
+    if pps is not None:
+        if not isinstance(pps, dict):
+            session_data["pending_product_selection"] = None
+        else:
+            pps.setdefault("quantity", None)
+
     return session_data


### PR DESCRIPTION
## Summary
- Track quantity in `pending_product_selection` and use it when adding items from numeric selections
- Validate and reset `pending_product_selection` to avoid leftover data between conversations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689be297f770832caed2084b0058a9f9