### PR TITLE
Padroniza chaves de sessão entre módulos

### DIFF
--- a/IA/ai_llm/llm_interface.py
+++ b/IA/ai_llm/llm_interface.py
@@ -191,7 +191,7 @@ def detect_checkout_context(session_data: Dict) -> Dict:
     }
     
     # Verifica histórico recente
-    history = session_data.get('conversation_history', [])
+    history = session_data.get('historico_conversa', [])
     
     if not history:
         return context
@@ -343,15 +343,15 @@ def enhance_context_awareness(user_message: str, session_data: Dict) -> Dict:
     """
     logging.debug(f"Aprimorando a consciência de contexto para a mensagem: '{user_message}'")
     context = {
-        "has_cart_items": len(session_data.get("shopping_cart", [])) > 0,
-        "cart_count": len(session_data.get("shopping_cart", [])),
-        "has_pending_products": len(session_data.get("last_shown_products", [])) > 0,
-        "last_action": session_data.get("last_bot_action", ""),
-        "customer_identified": bool(session_data.get("customer_context")),
-        "recent_search": session_data.get("last_kb_search_term"),
+        "has_cart_items": len(session_data.get("carrinho_compras", [])) > 0,
+        "cart_count": len(session_data.get("carrinho_compras", [])),
+        "has_pending_products": len(session_data.get("ultimos_produtos_mostrados", [])) > 0,
+        "last_action": session_data.get("ultima_acao_bot", ""),
+        "customer_identified": bool(session_data.get("contexto_cliente")),
+        "recent_search": session_data.get("ultimo_termo_busca_kb"),
         "numeric_selection": extract_numeric_selection(user_message),
         "inferred_quantity": detect_quantity_keywords(user_message),
-        "conversation_history": session_data.get("conversation_history", [])
+        "historico_conversa": session_data.get("historico_conversa", [])
     }
 
     # 🆕 DETECTA COMANDOS DE LIMPEZA DE CARRINHO
@@ -384,7 +384,7 @@ def enhance_context_awareness(user_message: str, session_data: Dict) -> Dict:
         context["continue_shopping"] = True
         
     context["conversation_context"] = analyze_conversation_context(
-        context["conversation_history"], user_message
+        context["historico_conversa"], user_message
     )
 
     # Detecta gírias de produtos
@@ -596,13 +596,13 @@ def get_intent(
 
         # Obtém contexto EXPANDIDO da conversa (14 mensagens para melhor contexto)
         conversation_context = obter_contexto_conversa(session_data, max_messages=14)
-        print(f">>> CONSOLE: Contexto da conversa com {len(session_data.get('conversation_history', []))} mensagens totais")
+        print(f">>> CONSOLE: Contexto da conversa com {len(session_data.get('historico_conversa', []))} mensagens totais")
 
         # Informações do carrinho
         cart_info = ""
         if cart_items_count > 0:
             cart_info = f"CARRINHO ATUAL: {cart_items_count} itens"
-            cart_items = session_data.get("shopping_cart", [])
+            cart_items = session_data.get("carrinho_compras", [])
             if cart_items:
                 cart_info += " ("
                 item_names = []
@@ -619,7 +619,7 @@ def get_intent(
 
         # Produtos disponíveis para seleção
         products_info = ""
-        last_shown = session_data.get("last_shown_products", [])
+        last_shown = session_data.get("ultimos_produtos_mostrados", [])
         if last_shown and enhanced_context.get("numeric_selection"):
             products_info = f"PRODUTOS MOSTRADOS RECENTEMENTE: {len(last_shown)} opções disponíveis para seleção numérica"
 
@@ -1128,7 +1128,7 @@ def get_enhanced_intent(
         user_message,
         session_data,
         customer_context,
-        len(session_data.get("shopping_cart", [])),
+        len(session_data.get("carrinho_compras", [])),
     )
 
     if not intent:
@@ -1248,8 +1248,8 @@ def generate_personalized_response(context_type: str, session_data: Dict, **kwar
     logging.debug(f"Gerando resposta personalizada para o tipo de contexto: '{context_type}'")
     try:
         # Constrói o contexto baseado no tipo
-        conversation_history = session_data.get("conversation_history", [])
-        cart_items = len(session_data.get("shopping_cart", []))
+        conversation_history = session_data.get("historico_conversa", [])
+        cart_items = len(session_data.get("carrinho_compras", []))
         
         # 🆕 PROMPTS PROFISSIONAIS: Mensagens curtas, naturais mas sem inventar dados
         contexts = {

--- a/IA/app.py
+++ b/IA/app.py
@@ -413,15 +413,15 @@ def sugerir_alternativas(termo_busca_falho: str) -> str:
 def _extract_state(session: Dict) -> Dict:
     """Extrai os dados relevantes da sessão em um dicionário mutável."""
     return {
-        "customer_context": session.get("customer_context"),
-        "shopping_cart": session.get("shopping_cart", []),
-        "last_search_type": session.get("last_search_type"),
-        "last_search_params": session.get("last_search_params", {}),
-        "current_offset": session.get("current_offset", 0),
-        "last_shown_products": session.get("last_shown_products", []),
-        "last_bot_action": session.get("last_bot_action"),
-        "pending_action": session.get("pending_action"),
-        "last_kb_search_term": session.get("last_kb_search_term"),
+        "contexto_cliente": session.get("contexto_cliente"),
+        "carrinho_compras": session.get("carrinho_compras", []),
+        "ultimo_tipo_busca": session.get("ultimo_tipo_busca"),
+        "ultimos_parametros_busca": session.get("ultimos_parametros_busca", {}),
+        "offset_atual": session.get("offset_atual", 0),
+        "ultimos_produtos_mostrados": session.get("ultimos_produtos_mostrados", []),
+        "ultima_acao_bot": session.get("ultima_acao_bot"),
+        "acao_pendente": session.get("acao_pendente"),
+        "ultimo_termo_busca_kb": session.get("ultimo_termo_busca_kb"),
     }
 
 
@@ -429,9 +429,9 @@ def _handle_pending_action(
     session: Dict, state: Dict, incoming_msg: str
 ) -> Tuple[Union[Dict, None], str]:
     """Processa ações pendentes existentes na sessão."""
-    pending_action = state.get("pending_action")
+    pending_action = state.get("acao_pendente")
     print(f">>> CONSOLE: pending_action atual: '{pending_action}'")
-    shopping_cart = state.get("shopping_cart", [])
+    shopping_cart = state.get("carrinho_compras", [])
     intent = None
     response_text = ""
 
@@ -440,7 +440,7 @@ def _handle_pending_action(
 
         # 🆕 Extrai quantidade usando IA-FIRST com fallback
         conversation_context = obter_contexto_conversa(session)
-        last_shown_products = state.get("last_shown_products", [])
+        last_shown_products = state.get("ultimos_produtos_mostrados", [])
         qt = extrair_quantidade_com_ia(incoming_msg, last_shown_products, conversation_context)
         
         # 🆕 FALLBACK: Se IA não conseguiu, usa extração básica
@@ -503,7 +503,7 @@ def _handle_pending_action(
                             "pending_product_for_cart": None,
                             "duplicate_item_index": duplicate_index + 1,
                             "duplicate_item_qty": qt,
-                            "pending_action": "AWAITING_DUPLICATE_DECISION",
+                            "acao_pendente": "AWAITING_DUPLICATE_DECISION",
                         },
                     )
 
@@ -543,14 +543,14 @@ def _handle_pending_action(
                     atualizar_contexto_sessao(
                         session,
                         {
-                            "pending_action": None,
+                            "acao_pendente": None,
                             "pending_product_for_cart": None,
-                            "last_bot_action": "AWAITING_CHECKOUT_CONFIRMATION",
+                            "ultima_acao_bot": "AWAITING_CHECKOUT_CONFIRMATION",
                         },
                     )
                     pending_action = None
                     # Define o estado correto para aguardar confirmação de checkout
-                    state["last_bot_action"] = "AWAITING_CHECKOUT_CONFIRMATION"
+                    state["ultima_acao_bot"] = "AWAITING_CHECKOUT_CONFIRMATION"
 
             else:
                 response_text = generate_personalized_response("error", session)
@@ -558,7 +558,7 @@ def _handle_pending_action(
                 atualizar_contexto_sessao(
                     session,
                     {
-                        "pending_action": None,
+                        "acao_pendente": None,
                         "pending_product_for_cart": None,
                     },
                 )
@@ -576,8 +576,8 @@ def _handle_pending_action(
             )
             pending_action = None
 
-        state["pending_action"] = pending_action
-        state["shopping_cart"] = shopping_cart
+        state["acao_pendente"] = pending_action
+        state["carrinho_compras"] = shopping_cart
 
     elif pending_action == "AWAITING_CART_ITEM_SELECTION":
         # Usuário está selecionando item do carrinho após ambiguidade
@@ -645,8 +645,8 @@ def _handle_pending_action(
                 session, "assistant", response_text, "REQUEST_CLARIFICATION"
             )
 
-        state["pending_action"] = pending_action
-        state["shopping_cart"] = shopping_cart
+        state["acao_pendente"] = pending_action
+        state["carrinho_compras"] = shopping_cart
 
     elif pending_action == "AWAITING_DUPLICATE_DECISION":
         print(">>> CONSOLE: Tratando ação pendente AWAITING_DUPLICATE_DECISION")
@@ -668,11 +668,11 @@ def _handle_pending_action(
                 {
                     "duplicate_item_index": None,
                     "duplicate_item_qty": None,
-                    "pending_action": None,
-                    "last_bot_action": "AWAITING_CHECKOUT_CONFIRMATION",
+                    "acao_pendente": None,
+                    "ultima_acao_bot": "AWAITING_CHECKOUT_CONFIRMATION",
                 },
             )
-            state["last_bot_action"] = "AWAITING_CHECKOUT_CONFIRMATION"
+            state["ultima_acao_bot"] = "AWAITING_CHECKOUT_CONFIRMATION"
         elif choice == "2":
             success, message, shopping_cart = atualizar_quantidade_item_carrinho(
                 shopping_cart, index, qty
@@ -687,11 +687,11 @@ def _handle_pending_action(
                 {
                     "duplicate_item_index": None,
                     "duplicate_item_qty": None,
-                    "pending_action": None,
-                    "last_bot_action": "AWAITING_CHECKOUT_CONFIRMATION",
+                    "acao_pendente": None,
+                    "ultima_acao_bot": "AWAITING_CHECKOUT_CONFIRMATION",
                 },
             )
-            state["last_bot_action"] = "AWAITING_CHECKOUT_CONFIRMATION"
+            state["ultima_acao_bot"] = "AWAITING_CHECKOUT_CONFIRMATION"
         else:
             if index and 1 <= index <= len(shopping_cart):
                 existing_item = shopping_cart[index - 1]
@@ -711,8 +711,8 @@ def _handle_pending_action(
                 session, "assistant", response_text, "REQUEST_DUPLICATE_DECISION"
             )
 
-        state["pending_action"] = pending_action
-        state["shopping_cart"] = shopping_cart
+        state["acao_pendente"] = pending_action
+        state["carrinho_compras"] = shopping_cart
 
     elif pending_action == "AWAITING_SMART_UPDATE_SELECTION":
         print(">>> CONSOLE: CHEGOU NO ELIF AWAITING_SMART_UPDATE_SELECTION")
@@ -776,10 +776,10 @@ def _handle_pending_action(
             # Limpa estado pendente
             atualizar_contexto_sessao(session, {
                 "pending_smart_update": None,
-                "pending_action": None
+                "acao_pendente": None
             })
             pending_action = None
-            state["pending_action"] = pending_action
+            state["acao_pendente"] = pending_action
             
             # Retorna uma intent fake para indicar que a ação foi processada
             return {"nome_ferramenta": "action_processed", "parametros": {}}, response_text
@@ -815,12 +815,12 @@ def _handle_pending_action(
             )
             adicionar_mensagem_historico(session, "assistant", response_text, "CHITCHAT")
             pending_action = None
-            state["last_shown_products"] = []
-            state["last_bot_action"] = "AWAITING_MENU_SELECTION"
+            state["ultimos_produtos_mostrados"] = []
+            state["ultima_acao_bot"] = "AWAITING_MENU_SELECTION"
         else:
             pending_action = None
 
-        state["pending_action"] = pending_action
+        state["acao_pendente"] = pending_action
 
     return None, response_text
 
@@ -831,15 +831,15 @@ def _process_user_message(
     Processa a mensagem do usuário e determina a intenção usando o novo fluxo de IA.
     """
     response_text = ""
-    shopping_cart = state.get("shopping_cart", [])
+    shopping_cart = state.get("carrinho_compras", [])
 
     if not incoming_msg:
         response_text = (
             "Me conta o que você precisa que eu te ajudo!\n\n"
             f"{formatar_acoes_rapidas(tem_carrinho=bool(shopping_cart))}"
         )
-        state["last_shown_products"] = []
-        state["last_bot_action"] = "AWAITING_MENU_SELECTION"
+        state["ultimos_produtos_mostrados"] = []
+        state["ultima_acao_bot"] = "AWAITING_MENU_SELECTION"
         adicionar_mensagem_historico(
             session, "assistant", response_text, "REQUEST_CLARIFICATION"
         )
@@ -868,12 +868,12 @@ def _process_user_message(
     # 🚨 PRIORIDADE MÁXIMA: Detecta números de menu principal (mas não CNPJ)
     if incoming_msg.strip().isdigit() and not is_cnpj_format(incoming_msg.strip()):
         numero = int(incoming_msg.strip())
-        ultima_acao = state.get("last_bot_action", "")
+        ultima_acao = state.get("ultima_acao_bot", "")
         
-        print(f">>> CONSOLE: Número {numero} detectado, ultima_acao='{ultima_acao}', tem_carrinho={bool(shopping_cart)}, produtos_mostrados={len(state.get('last_shown_products', []))}")
+        print(f">>> CONSOLE: Número {numero} detectado, ultima_acao='{ultima_acao}', tem_carrinho={bool(shopping_cart)}, produtos_mostrados={len(state.get('ultimos_produtos_mostrados', []))}")
         
         # Se é contexto de menu e não tem produtos para selecionar
-        if ultima_acao == "AWAITING_MENU_SELECTION" and not state.get("last_shown_products"):
+        if ultima_acao == "AWAITING_MENU_SELECTION" and not state.get("ultimos_produtos_mostrados"):
             print(f">>> CONSOLE: Processando seleção de menu {numero}")
             if numero == 1:
                 intent = {"nome_ferramenta": "smart_search_with_promotions", "parametros": {"search_term": "produtos"}}
@@ -886,8 +886,8 @@ def _process_user_message(
                 return intent, response_text
         
         # 🎯 NOVA CONDIÇÃO: Se é contexto de seleção de produto e tem produtos para selecionar
-        elif ultima_acao == "AWAITING_PRODUCT_SELECTION" and state.get("last_shown_products"):
-            produtos_mostrados = state.get("last_shown_products", [])
+        elif ultima_acao == "AWAITING_PRODUCT_SELECTION" and state.get("ultimos_produtos_mostrados"):
+            produtos_mostrados = state.get("ultimos_produtos_mostrados", [])
             if 1 <= numero <= len(produtos_mostrados):
                 print(f">>> CONSOLE: Processando seleção de produto {numero}")
                 intent = {"nome_ferramenta": "add_item_to_cart", "parametros": {"index": numero}}
@@ -941,7 +941,7 @@ def _processar_pedido_complexo(session: Dict, state: Dict, pedidos_complexos: Li
     Returns:
         str: Resposta formatada para o usuário.
     """
-    shopping_cart = state.get("shopping_cart", [])
+    shopping_cart = state.get("carrinho_compras", [])
     itens_adicionados = []
     itens_nao_encontrados = []
     
@@ -968,8 +968,8 @@ def _processar_pedido_complexo(session: Dict, state: Dict, pedidos_complexos: Li
             itens_nao_encontrados.append(f"{quantidade}x {produto_nome}")
     
     # Atualiza o estado
-    state["shopping_cart"] = shopping_cart
-    state["last_bot_action"] = "COMPLEX_ORDER_PROCESSED"
+    state["carrinho_compras"] = shopping_cart
+    state["ultima_acao_bot"] = "COMPLEX_ORDER_PROCESSED"
     
     # Gera resposta
     if itens_adicionados:
@@ -988,15 +988,15 @@ def _processar_pedido_complexo(session: Dict, state: Dict, pedidos_complexos: Li
 
 def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str, incoming_msg: str = "") -> str:
     """Executa a ferramenta baseada na intenção identificada com IA-FIRST."""
-    customer_context = state.get("customer_context")
-    shopping_cart = state.get("shopping_cart", [])
-    last_search_type = state.get("last_search_type")
-    last_search_params = state.get("last_search_params", {})
-    current_offset = state.get("current_offset", 0)
-    last_shown_products = state.get("last_shown_products", [])
-    last_bot_action = state.get("last_bot_action")
-    pending_action = state.get("pending_action")
-    last_kb_search_term = state.get("last_kb_search_term")
+    customer_context = state.get("contexto_cliente")
+    shopping_cart = state.get("carrinho_compras", [])
+    last_search_type = state.get("ultimo_tipo_busca")
+    last_search_params = state.get("ultimos_parametros_busca", {})
+    current_offset = state.get("offset_atual", 0)
+    last_shown_products = state.get("ultimos_produtos_mostrados", [])
+    last_bot_action = state.get("ultima_acao_bot")
+    pending_action = state.get("acao_pendente")
+    last_kb_search_term = state.get("ultimo_termo_busca_kb")
     
     # 🆕 IA-FIRST: Detecta pedidos complexos (múltiplos produtos)
     user_message = intent.get("user_message", "")
@@ -1123,12 +1123,12 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str, inc
                 last_bot_action = "AWAITING_PRODUCT_SELECTION"
                 
                 # 🆕 SALVA PRODUTOS NO ESTADO PARA PERMITIR SELEÇÃO NUMÉRICA
-                state["last_shown_products"] = last_shown_products
-                state["last_bot_action"] = last_bot_action
+                state["ultimos_produtos_mostrados"] = last_shown_products
+                state["ultima_acao_bot"] = last_bot_action
                 
                 # 🔧 ATUALIZA TAMBÉM AS VARIÁVEIS LOCAIS PARA SEREM SALVAS NO FINAL
-                last_shown_products = state["last_shown_products"]  # Atualiza variável local
-                last_bot_action = state["last_bot_action"]  # Atualiza variável local
+                last_shown_products = state["ultimos_produtos_mostrados"]  # Atualiza variável local
+                last_bot_action = state["ultima_acao_bot"]  # Atualiza variável local
                 
                 adicionar_mensagem_historico(session, "assistant", response_text, "SHOW_CHEAPEST_PROMOTIONS")
         
@@ -1224,12 +1224,12 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                     last_bot_action = "AWAITING_PRODUCT_SELECTION"
                     
                     # 🆕 SALVA PRODUTOS NO ESTADO PARA PERMITIR SELEÇÃO NUMÉRICA
-                    state["last_shown_products"] = last_shown_products
-                    state["last_bot_action"] = last_bot_action
+                    state["ultimos_produtos_mostrados"] = last_shown_products
+                    state["ultima_acao_bot"] = last_bot_action
                     
                     # 🔧 ATUALIZA TAMBÉM AS VARIÁVEIS LOCAIS PARA SEREM SALVAS NO FINAL
-                    last_shown_products = state["last_shown_products"]  # Atualiza variável local
-                    last_bot_action = state["last_bot_action"]  # Atualiza variável local
+                    last_shown_products = state["ultimos_produtos_mostrados"]  # Atualiza variável local
+                    last_bot_action = state["ultima_acao_bot"]  # Atualiza variável local
                     
                     adicionar_mensagem_historico(session, "assistant", response_text, "SHOW_PRODUCTS_FROM_KB")
                     
@@ -1256,12 +1256,12 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                         last_bot_action = "AWAITING_PRODUCT_SELECTION"
                         
                         # 🆕 SALVA PRODUTOS NO ESTADO PARA PERMITIR SELEÇÃO NUMÉRICA
-                        state["last_shown_products"] = last_shown_products
-                        state["last_bot_action"] = last_bot_action
+                        state["ultimos_produtos_mostrados"] = last_shown_products
+                        state["ultima_acao_bot"] = last_bot_action
                         
                         # 🔧 ATUALIZA TAMBÉM AS VARIÁVEIS LOCAIS PARA SEREM SALVAS NO FINAL
-                        last_shown_products = state["last_shown_products"]  # Atualiza variável local
-                        last_bot_action = state["last_bot_action"]  # Atualiza variável local
+                        last_shown_products = state["ultimos_produtos_mostrados"]  # Atualiza variável local
+                        last_bot_action = state["ultima_acao_bot"]  # Atualiza variável local
                         
                         adicionar_mensagem_historico(session, "assistant", response_text, "SHOW_PRODUCTS_FROM_DB")
                     else:
@@ -1455,8 +1455,8 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                             )
                     
                     # 🆕 SALVA PRODUTOS NO ESTADO PARA PERMITIR SELEÇÃO NUMÉRICA E "MAIS"
-                    state["last_shown_products"] = last_shown_products
-                    state["last_bot_action"] = last_bot_action
+                    state["ultimos_produtos_mostrados"] = last_shown_products
+                    state["ultima_acao_bot"] = last_bot_action
                     
                     # 🆕 SALVA PARÂMETROS PARA FUNCIONAR COM "MAIS"
                     last_search_type = "smart_search"
@@ -1469,8 +1469,8 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                     print(f">>> DEBUG: [SALVAR_BUSCA] Salvando busca inteligente - tipo: {last_search_type}, params: {last_search_params}")
                     
                     # 🔧 ATUALIZA TAMBÉM AS VARIÁVEIS LOCAIS PARA SEREM SALVAS NO FINAL
-                    last_shown_products = state["last_shown_products"]  # Atualiza variável local
-                    last_bot_action = state["last_bot_action"]  # Atualiza variável local
+                    last_shown_products = state["ultimos_produtos_mostrados"]  # Atualiza variável local
+                    last_bot_action = state["ultima_acao_bot"]  # Atualiza variável local
                     
                     adicionar_mensagem_historico(session, "assistant", response_text, "SHOW_SMART_SEARCH_RESULTS")
                     
@@ -1678,7 +1678,7 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                 {
                     "pending_product_for_cart": product_to_add,
                     "term_to_learn_after_quantity": term_to_learn,
-                    "pending_action": "AWAITING_QUANTITY",
+                    "acao_pendente": "AWAITING_QUANTITY",
                 },
             )
             pending_action = "AWAITING_QUANTITY"
@@ -1717,7 +1717,7 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                         "pending_cart_matches": matches,
                         "pending_cart_action": "remove",
                         "pending_cart_quantity": quantity,
-                        "pending_action": pending_action,
+                        "acao_pendente": pending_action,
                     },
                 )
                 response_text = f"{formatar_carrinho_com_indices(shopping_cart)}\n\nDigite o número do item que deseja remover."
@@ -1732,15 +1732,15 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                 )
                 state.update(
                     {
-                        "customer_context": customer_context,
-                        "shopping_cart": shopping_cart,
-                        "last_search_type": last_search_type,
-                        "last_search_params": last_search_params,
-                        "current_offset": current_offset,
-                        "last_shown_products": last_shown_products,
-                        "last_bot_action": "AWAITING_MENU_SELECTION",
-                        "pending_action": pending_action,
-                        "last_kb_search_term": last_kb_search_term,
+                        "contexto_cliente": customer_context,
+                        "carrinho_compras": shopping_cart,
+                        "ultimo_tipo_busca": last_search_type,
+                        "ultimos_parametros_busca": last_search_params,
+                        "offset_atual": current_offset,
+                        "ultimos_produtos_mostrados": last_shown_products,
+                        "ultima_acao_bot": "AWAITING_MENU_SELECTION",
+                        "acao_pendente": pending_action,
+                        "ultimo_termo_busca_kb": last_kb_search_term,
                     }
                 )
                 return response_text
@@ -1771,7 +1771,7 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                         "pending_cart_matches": matches,
                         "pending_cart_action": pending_cart_action,
                         "pending_cart_quantity": quantity,
-                        "pending_action": pending_action,
+                        "acao_pendente": pending_action,
                     },
                 )
                 options = "\n".join(
@@ -1922,9 +1922,9 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
         atualizar_contexto_sessao(
             session,
             {
-                "shopping_cart": shopping_cart,
-                "pending_action": pending_action,
-                "last_bot_action": last_bot_action,
+                "carrinho_compras": shopping_cart,
+                "acao_pendente": pending_action,
+                "ultima_acao_bot": last_bot_action,
             },
         )
         response_text = (
@@ -2086,7 +2086,7 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
         else:
             # 🚀 IA-FIRST: DETECÇÃO INTELIGENTE DE "MAIS PRODUTOS"
             # Obtém a última mensagem do usuário do histórico
-            history = session.get('conversation_history', [])
+            history = session.get('historico_conversa', [])
             last_user_message = ""
             for msg in reversed(history):
                 if msg.get('role') == 'user':
@@ -2208,7 +2208,7 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                 # Limpa ação pendente
                 atualizar_contexto_sessao(session, {
                     "pending_smart_update": None,
-                    "pending_action": None
+                    "acao_pendente": None
                 })
                 pending_action = None
                 
@@ -2224,7 +2224,7 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
             # Limpa ação pendente em caso de erro
             atualizar_contexto_sessao(session, {
                 "pending_smart_update": None,
-                "pending_action": None
+                "acao_pendente": None
             })
             pending_action = None
 
@@ -2334,7 +2334,7 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                         "matching_items": matching_items,
                         "product_name": product_name
                     },
-                    "pending_action": "AWAITING_SMART_UPDATE_SELECTION"
+                    "acao_pendente": "AWAITING_SMART_UPDATE_SELECTION"
                 })
                 pending_action = "AWAITING_SMART_UPDATE_SELECTION"
             
@@ -2353,15 +2353,15 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
 
     state.update(
         {
-            "customer_context": customer_context,
-            "shopping_cart": shopping_cart,
-            "last_search_type": last_search_type,
-            "last_search_params": last_search_params,
-            "current_offset": current_offset,
-            "last_shown_products": last_shown_products,
-            "last_bot_action": last_bot_action,
-            "pending_action": pending_action,
-            "last_kb_search_term": last_kb_search_term,
+            "contexto_cliente": customer_context,
+            "carrinho_compras": shopping_cart,
+            "ultimo_tipo_busca": last_search_type,
+            "ultimos_parametros_busca": last_search_params,
+            "offset_atual": current_offset,
+            "ultimos_produtos_mostrados": last_shown_products,
+            "ultima_acao_bot": last_bot_action,
+            "acao_pendente": pending_action,
+            "ultimo_termo_busca_kb": last_kb_search_term,
         }
     )
 
@@ -2383,22 +2383,22 @@ def _finalize_session(
     atualizar_contexto_sessao(
         session,
         {
-            "customer_context": state.get("customer_context"),
-            "shopping_cart": state.get("shopping_cart", []),
-            "last_search_type": state.get("last_search_type"),
-            "last_search_params": state.get("last_search_params", {}),
-            "current_offset": state.get("current_offset", 0),
-            "last_shown_products": state.get("last_shown_products", []),
-            "last_bot_action": state.get("last_bot_action"),
-            "pending_action": state.get("pending_action"),
-            "last_kb_search_term": state.get("last_kb_search_term"),
+            "contexto_cliente": state.get("contexto_cliente"),
+            "carrinho_compras": state.get("carrinho_compras", []),
+            "ultimo_tipo_busca": state.get("ultimo_tipo_busca"),
+            "ultimos_parametros_busca": state.get("ultimos_parametros_busca", {}),
+            "offset_atual": state.get("offset_atual", 0),
+            "ultimos_produtos_mostrados": state.get("ultimos_produtos_mostrados", []),
+            "ultima_acao_bot": state.get("ultima_acao_bot"),
+            "acao_pendente": state.get("acao_pendente"),
+            "ultimo_termo_busca_kb": state.get("ultimo_termo_busca_kb"),
         },
     )
     
     if response_text:
         # 📝 SEMPRE salva a resposta no histórico antes de tentar enviar 
         # 🆕 EVITA DUPLICAÇÃO: Só salva se não for idêntica à última mensagem
-        history = session.get("conversation_history", [])
+        history = session.get("historico_conversa", [])
         last_msg = history[-1] if history else {}
         if not (last_msg.get("role") == "assistant" and last_msg.get("message") == response_text):
             adicionar_mensagem_historico(session, "assistant", response_text, "BOT_RESPONSE")
@@ -2498,8 +2498,8 @@ def _validate_cnpj_first(sender_phone: str, incoming_msg: str) -> Tuple[bool, st
         
         # Carrega sessão temporária e adiciona CNPJ validado
         temp_session["validated_cnpj"] = cnpj_clean
-        temp_session["customer_context"] = temp_session.get("customer_context", {})
-        temp_session["customer_context"]["cnpj"] = cnpj_clean
+        temp_session["contexto_cliente"] = temp_session.get("contexto_cliente", {})
+        temp_session["contexto_cliente"]["cnpj"] = cnpj_clean
         
         # Salva na nova sessão com CNPJ
         salvar_sessao(session_id_with_cnpj, temp_session)
@@ -2649,7 +2649,7 @@ def process_message_async(sender_phone: str, incoming_msg: str):
             # 2.1. PRIORIDADE ESPECIAL: Se detectou checkout, limpa ações pendentes conflitantes
             if intent and intent.get("nome_ferramenta") == "checkout":
                 if intent.get("parametros", {}).get("force_checkout"):
-                    state["pending_action"] = None  # Limpa qualquer ação pendente
+                    state["acao_pendente"] = None  # Limpa qualquer ação pendente
                     print(">>> CONSOLE: Checkout forçado - limpando ações pendentes")
 
             # 3. Executa a intenção identificada
@@ -2669,14 +2669,14 @@ def process_message_async(sender_phone: str, incoming_msg: str):
                     )
 
             # 4. Mensagem padrão caso nenhuma resposta seja definida
-            if not response_text and not state.get("pending_action"):
+            if not response_text and not state.get("acao_pendente"):
                 # Não adiciona quick_actions se estiver aguardando confirmação de checkout
-                if state.get("last_bot_action") == "AWAITING_CHECKOUT_CONFIRMATION":
+                if state.get("ultima_acao_bot") == "AWAITING_CHECKOUT_CONFIRMATION":
                     response_text = "Operação concluída."
                 else:
                     response_text = (
                         "Operação concluída. O que mais posso fazer por você?\n\n"
-                        f"{formatar_acoes_rapidas(tem_carrinho=bool(state.get('shopping_cart', [])))}"
+                        f"{formatar_acoes_rapidas(tem_carrinho=bool(state.get('carrinho_compras', [])))}"
                     )
                 adicionar_mensagem_historico(
                     session, "assistant", response_text, "OPERATION_COMPLETE"
@@ -2763,7 +2763,7 @@ def process_message_for_web(sender_id: str, incoming_msg: str) -> str:
                 original_sender_id = sender_id.split('_')[0] if '_' in session_id else sender_id
                 response_text = _route_tool(session, state, intent, original_sender_id, incoming_msg)
             
-            if not response_text and not state.get("pending_action"):
+            if not response_text and not state.get("acao_pendente"):
                 response_text = "Operação concluída. O que mais posso fazer por você?"
                 adicionar_mensagem_historico(session, "assistant", response_text, "OPERATION_COMPLETE")
 
@@ -2790,20 +2790,20 @@ def _finalize_session_for_web(sender_id: str, session: Dict, state: Dict, respon
     atualizar_contexto_sessao(
         session,
         {
-            "customer_context": state.get("customer_context"),
-            "shopping_cart": state.get("shopping_cart", []),
-            "last_search_type": state.get("last_search_type"),
-            "last_search_params": state.get("last_search_params", {}),
-            "current_offset": state.get("current_offset", 0),
-            "last_shown_products": state.get("last_shown_products", []),
-            "last_bot_action": state.get("last_bot_action"),
-            "pending_action": state.get("pending_action"),
-            "last_kb_search_term": state.get("last_kb_search_term"),
+            "contexto_cliente": state.get("contexto_cliente"),
+            "carrinho_compras": state.get("carrinho_compras", []),
+            "ultimo_tipo_busca": state.get("ultimo_tipo_busca"),
+            "ultimos_parametros_busca": state.get("ultimos_parametros_busca", {}),
+            "offset_atual": state.get("offset_atual", 0),
+            "ultimos_produtos_mostrados": state.get("ultimos_produtos_mostrados", []),
+            "ultima_acao_bot": state.get("ultima_acao_bot"),
+            "acao_pendente": state.get("acao_pendente"),
+            "ultimo_termo_busca_kb": state.get("ultimo_termo_busca_kb"),
         },
     )
     if response_text:
         # 🆕 EVITA DUPLICAÇÃO: Só salva se não for idêntica à última mensagem
-        history = session.get("conversation_history", [])
+        history = session.get("historico_conversa", [])
         last_msg = history[-1] if history else {}
         if not (last_msg.get("role") == "assistant" and last_msg.get("message") == response_text):
             adicionar_mensagem_historico(session, "assistant", response_text, "BOT_RESPONSE")
@@ -2918,15 +2918,15 @@ def clear_cart_endpoint():
         return jsonify({"error": "user_id é obrigatório"}), 400
     
     session = carregar_sessao(user_id)
-    shopping_cart = session.get("shopping_cart", [])
+    shopping_cart = session.get("carrinho_compras", [])
     
     message, empty_cart = limpar_carrinho_completamente(shopping_cart)
-    session["shopping_cart"] = empty_cart
+    session["carrinho_compras"] = empty_cart
     
     # Atualiza estado da sessão
-    session["last_bot_action"] = "AWAITING_MENU_SELECTION"
-    session["pending_action"] = None
-    session["last_shown_products"] = []
+    session["ultima_acao_bot"] = "AWAITING_MENU_SELECTION"
+    session["acao_pendente"] = None
+    session["ultimos_produtos_mostrados"] = []
     
     adicionar_mensagem_historico(session, "assistant", message, "CLEAR_CART_API")
     salvar_sessao(user_id, session)


### PR DESCRIPTION
## Summary
- Alinha app e interface LLM às chaves do gerenciador de sessão
- Garante consistência ao extrair e usar estado da sessão

## Testing
- `python -m py_compile IA/app.py IA/ai_llm/llm_interface.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'utils.category_classifier')*
- Manual session save/load script

------
https://chatgpt.com/codex/tasks/task_e_68a73112faf8832c8078934218c28d55