### PR TITLE
Restringe limpeza do carrinho a comandos explícitos

### DIFF
--- a/IA/core/gerenciador_sessao.py
+++ b/IA/core/gerenciador_sessao.py
@@ -537,20 +537,33 @@ def detectar_comandos_limpar_carrinho(mensagem: str) -> bool:
         'do zero', 'novo pedido', 'nova compra',
         'limpa carrinho', 'esvazia carrinho', 'zera carrinho'
     ]
-    
+
     if mensagem_minuscula in comandos_limpar:
         logging.debug("Comando de limpar carrinho detectado.")
         return True
-    
+
+    verbos_limpeza = [
+        'esvaziar', 'esvazia', 'limpar', 'limpa', 'zerar', 'zera',
+        'apagar', 'apaga', 'deletar', 'deleta', 'remover', 'remove',
+        'resetar', 'reseta'
+    ]
+    termos_carrinho = [
+        'carrinho', 'tudo', 'todos', 'cesta', 'compra', 'compras', 'pedido'
+    ]
+
+    if any(v in mensagem_minuscula for v in verbos_limpeza) and \
+       any(t in mensagem_minuscula for t in termos_carrinho):
+        logging.debug("Verbo de limpeza com termo relacionado a carrinho detectado.")
+        return True
+
     padroes_limpar = [
-        r'\b(esvaziar|limpar|zerar|apagar|deletar|remover)\s+(o\s+)?carrinho\b',
         r'\b(carrinho|tudo)\s+(vazio|limpo|zerado)\b',
         r'\bcomeca\w*\s+de\s+novo\b',
-        r'\bdo\s+zero\b',
+        r'\brecome\w*\b',
         r'\breinicia\w*\s+(carrinho|tudo|compra)\b',
-        r'\b(esvazia|limpa|zera)\s+(carrinho|tudo)?\b'
+        r'\bdo\s+zero\b'
     ]
-    
+
     for padrao in padroes_limpar:
         if re.search(padrao, mensagem_minuscula):
             logging.debug("Padrão de limpar carrinho detectado.")

--- a/IA/utils/extrator_quantidade.py
+++ b/IA/utils/extrator_quantidade.py
@@ -300,14 +300,11 @@ def detectar_modificadores_quantidade(texto: str) -> Dict:
         modificadores['acao'] = 'set'
     elif re.search(r'\b(?:remover|tirar|excluir|deletar)\b', normalizado):
         modificadores['acao'] = 'remove'
-    # NOVO: Comando para esvaziar carrinho COMPLETO
-    elif re.search(r'\b(?:esvaziar|limpar|zerar|resetar|apagar)\s*(?:carrinho|tudo|todos|completo)?', normalizado):
-        modificadores['acao'] = 'clear'
-        modificadores['referencia'] = 'all'
-    # NOVO: Comandos alternativos para limpeza
-    elif re.search(r'\b(?:começar\s+de\s+novo|recomeçar|reiniciar)', normalizado):
-        modificadores['acao'] = 'clear'
-        modificadores['referencia'] = 'all'
+    else:
+        from core.gerenciador_sessao import detectar_comandos_limpar_carrinho
+        if detectar_comandos_limpar_carrinho(texto):
+            modificadores['acao'] = 'clear'
+            modificadores['referencia'] = 'all'
     
     # Referências - EXPANDIDO
     if re.search(r'\b(?:tudo|todos|todas|carrinho|completo|inteiro|total)\b', normalizado):

--- a/test_limpar_carrinho.py
+++ b/test_limpar_carrinho.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Testes para detecção de comandos de limpar carrinho."""
+
+import os
+import sys
+
+# Permite importar módulos da pasta IA
+sys.path.append(os.path.join(os.path.dirname(__file__), "IA"))
+
+from core.gerenciador_sessao import detectar_comandos_limpar_carrinho
+from utils.extrator_quantidade import detectar_modificadores_quantidade
+
+
+def test_limpa_isso_nao_limpa_carrinho():
+    """Expressões sem referência ao carrinho não devem limpar."""
+    assert not detectar_comandos_limpar_carrinho("limpa isso")
+
+
+def test_modificadores_limpa_isso_nao_limpa():
+    """Modificador não deve interpretar "limpa isso" como limpar carrinho."""
+    mods = detectar_modificadores_quantidade("limpa isso")
+    assert mods["acao"] != "clear"
+
+
+def test_limpa_carrinho_detectado():
+    """Comando válido deve ser detectado."""
+    assert detectar_comandos_limpar_carrinho("limpa o carrinho")
+


### PR DESCRIPTION
## Summary
- Evita que verbos de limpeza atuem sem menção ao carrinho
- Reutiliza `detectar_comandos_limpar_carrinho` em `detectar_modificadores_quantidade`
- Adiciona testes garantindo que "limpa isso" não esvazia o carrinho

## Testing
- `pytest -q` *(falha: ModuleNotFoundError: No module named 'utils.category_classifier')*
- `pytest test_limpar_carrinho.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73703f378832ca4848d332f1339ac