### PR TITLE
Add Counter import for session manager

### DIFF
--- a/IA/core/gerenciador_sessao.py
+++ b/IA/core/gerenciador_sessao.py
@@ -7,6 +7,7 @@ import os
 import json
 import logging
 import pickle
+from collections import Counter
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Union, Any
 import redis


### PR DESCRIPTION
## Summary
- import `Counter` in `gerenciador_sessao.py` to support word frequency summarization

## Testing
- `python -m py_compile IA/core/gerenciador_sessao.py`
- ❌ `pip install flake8` *(proxy 403, unable to install)*

------
https://chatgpt.com/codex/tasks/task_e_68a74913b23c832ca86be2fa603d5687