### PR TITLE
Renomeia update_cart_item para atualizar_item_carrinho

### DIFF
--- a/IA/ai_llm/llm_interface.py
+++ b/IA/ai_llm/llm_interface.py
@@ -291,7 +291,7 @@ def get_fallback_prompt() -> str:
 
 ESTILO: Respostas curtas com próxima ação explícita. Liste até 3 opções por vez; peça escolha por número ("1, 2 ou 3").
 
-FERRAMENTAS: get_top_selling_products, get_top_selling_products_by_name, add_item_to_cart, view_cart, update_cart_item, checkout, handle_chitchat, ask_continue_or_checkout, clear_cart
+FERRAMENTAS: get_top_selling_products, get_top_selling_products_by_name, add_item_to_cart, view_cart, atualizar_item_carrinho, checkout, handle_chitchat, ask_continue_or_checkout, clear_cart
 
 COMANDOS ESPECIAIS:
 - "esvaziar carrinho", "limpar carrinho" → use clear_cart
@@ -1063,11 +1063,19 @@ def validate_intent_parameters(tool_name: str, parameters: Dict) -> Dict:
         # Limita tamanho do nome do produto
         parameters["product_name"] = str(parameters["product_name"])[:100]
 
-    elif tool_name == "update_cart_item":
+    elif tool_name == "atualizar_item_carrinho":
         # Valida ação e parâmetros relacionados
-        valid_actions = ["remove", "update_quantity", "add_quantity"]
-        if "action" not in parameters or parameters["action"] not in valid_actions:
-            parameters["action"] = "remove"
+        valid_actions = ["remove", "add", "set"]
+        if "acao" not in parameters or parameters["acao"] not in valid_actions:
+            parameters["acao"] = "remove"
+        if "quantidade" in parameters:
+            try:
+                qt = float(parameters["quantidade"])
+                if qt <= 0:
+                    qt = 1
+                parameters["quantidade"] = qt
+            except (ValueError, TypeError):
+                parameters["quantidade"] = 1
     
     elif tool_name == "find_customer_by_cnpj":
         # 🆕 VALIDA CNPJ

--- a/IA/app.py
+++ b/IA/app.py
@@ -1696,19 +1696,19 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                 session, "assistant", response_text, "PRODUCT_NOT_FOUND"
             )
 
-    elif tool_name == "update_cart_item":
-        action = parameters.get("action")
-        quantity = parameters.get("qt", 1)
+    elif tool_name == "atualizar_item_carrinho":
+        acao = parameters.get("acao")
+        quantidade = parameters.get("quantidade", 1)
         try:
-            quantity = float(quantity)
+            quantidade = float(quantidade)
         except (ValueError, TypeError):
-            quantity = 1
+            quantidade = 1
 
-        index = parameters.get("index")
-        product_name = parameters.get("product_name")
+        indice = parameters.get("indice")
+        nome_produto = parameters.get("nome_produto")
         matched_index = None
 
-        if action == "remove" and not index and not product_name:
+        if acao == "remove" and not indice and not nome_produto:
             if shopping_cart:
                 matches = list(enumerate(shopping_cart))
                 pending_action = "AWAITING_CART_ITEM_SELECTION"
@@ -1717,7 +1717,7 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                     {
                         "pending_cart_matches": matches,
                         "pending_cart_action": "remove",
-                        "pending_cart_quantity": quantity,
+                        "pending_cart_quantity": quantidade,
                         "pending_action": pending_action,
                     },
                 )
@@ -1748,30 +1748,30 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
 
             last_bot_action = "AWAITING_MENU_SELECTION"
 
-        if index:
+        if indice:
             try:
-                idx = int(index)
+                idx = int(indice)
                 if 1 <= idx <= len(shopping_cart):
                     matched_index = idx
             except (ValueError, TypeError):
                 pass
-        elif product_name:
-            matches = encontrar_produtos_carrinho_por_nome(shopping_cart, product_name)
+        elif nome_produto:
+            matches = encontrar_produtos_carrinho_por_nome(shopping_cart, nome_produto)
             if len(matches) == 1:
                 matched_index = matches[0][0] + 1
             elif len(matches) > 1:
                 pending_action = "AWAITING_CART_ITEM_SELECTION"
                 pending_cart_action = (
                     "remove"
-                    if action == "remove"
-                    else ("add" if action == "add_quantity" else "update")
+                    if acao == "remove"
+                    else ("add" if acao == "add" else "set")
                 )
                 atualizar_contexto_sessao(
                     session,
                     {
                         "pending_cart_matches": matches,
                         "pending_cart_action": pending_cart_action,
-                        "pending_cart_quantity": quantity,
+                        "pending_cart_quantity": quantidade,
                         "pending_action": pending_action,
                     },
                 )
@@ -1787,23 +1787,23 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
                 )
 
         if matched_index is not None:
-            if action == "remove":
+            if acao == "remove":
                 success, response_text, shopping_cart = remover_item_do_carrinho(
                     shopping_cart, matched_index
                 )
                 adicionar_mensagem_historico(
                     session, "assistant", response_text, "REMOVE_FROM_CART"
                 )
-            elif action == "add_quantity":
+            elif acao == "add":
                 success, response_text, shopping_cart = adicionar_quantidade_item_carrinho(
-                    shopping_cart, matched_index, quantity
+                    shopping_cart, matched_index, quantidade
                 )
                 adicionar_mensagem_historico(
                     session, "assistant", response_text, "ADD_QUANTITY_TO_CART"
                 )
-            elif action == "update_quantity":
+            elif acao == "set":
                 success, response_text, shopping_cart = atualizar_quantidade_item_carrinho(
-                    shopping_cart, matched_index, quantity
+                    shopping_cart, matched_index, quantidade
                 )
                 adicionar_mensagem_historico(
                     session, "assistant", response_text, "UPDATE_CART_ITEM"


### PR DESCRIPTION
## Summary
- Atualiza a ferramenta de manipulação do carrinho para `atualizar_item_carrinho`
- Ajusta validações e prompt de fallback para novo nome e parâmetros em português

## Testing
- `pytest -q` *(falhou: ModuleNotFoundError: No module named 'utils.category_classifier')*

------
https://chatgpt.com/codex/tasks/task_e_68a75898d07c832cad28e5f5dfa504ab