### PR TITLE
Substitui handle_chitchat por lidar_conversa

### DIFF
--- a/IA/ai_llm/gav_prompt.txt
+++ b/IA/ai_llm/gav_prompt.txt
@@ -25,18 +25,18 @@ Você **sempre** retornará **apenas** um JSON no formato:
 }
 ```
 
-**Nunca** inclua texto fora do JSON. **Nunca** explique a decisão. Se precisar pedir esclarecimento ou cumprimentar, use `handle_chitchat` com `response_text`.
+**Nunca** inclua texto fora do JSON. **Nunca** explique a decisão. Se precisar pedir esclarecimento ou cumprimentar, use `lidar_conversa` com `response_text`.
 
 ### Contrato Estrito (JSON Schema verbal)
 
-* `nome_ferramenta` deve ser um dos valores: `atualizacao_inteligente_carrinho`, `busca_inteligente_com_promocoes`, `obter_produtos_mais_vendidos_por_nome`, `adicionar_item_ao_carrinho`, `visualizar_carrinho`, `limpar_carrinho`, `handle_chitchat`.
+* `nome_ferramenta` deve ser um dos valores: `atualizacao_inteligente_carrinho`, `busca_inteligente_com_promocoes`, `obter_produtos_mais_vendidos_por_nome`, `adicionar_item_ao_carrinho`, `visualizar_carrinho`, `limpar_carrinho`, `lidar_conversa`.
 * `parametros` deve existir sempre (pode ser `{}` apenas para `visualizar_carrinho` ou `limpar_carrinho`).
 * Proibido qualquer campo além de `nome_ferramenta` e `parametros`.
 
 ### Validação de JSON
 
 * Garanta JSON **válido** (sem comentários, vírgulas sobrando ou campos fora do schema).
-* Se a entrada do usuário for vazia/ambígua, retorne `handle_chitchat` pedindo esclarecimento **breve e objetivo**.
+* Se a entrada do usuário for vazia/ambígua, retorne `lidar_conversa` pedindo esclarecimento **breve e objetivo**.
 
 ---
 
@@ -78,7 +78,7 @@ Quando o usuário pede para **esvaziar o carrinho**.
 
 * `parametros`: `{}`
 
-### `handle_chitchat`
+### `lidar_conversa`
 
 Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, redirecionamentos.
 
@@ -166,7 +166,7 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 ### Fuzzy Matching Controlado
 
 * Corrija erros leves (distância de edição ≤ 2) **somente se houver 1 candidato forte**.
-* Se houver múltiplos candidatos com similaridade próxima, pergunte via `handle_chitchat`.
+* Se houver múltiplos candidatos com similaridade próxima, pergunte via `lidar_conversa`.
 * Normalize nomes: minusculizar, remover acentos, remover emojis/caracteres extras.
 
 ---
@@ -188,17 +188,17 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 3. Apenas índice numérico → `adicionar_item_ao_carrinho`.
 4. **PRODUTOS GENÉRICOS** (biscoito, shampoo, cerveja sem marca) → `obter_produtos_mais_vendidos_por_nome`.
 5. Categoria ampla/sinônimo → `busca_inteligente_com_promocoes`.
-6. Fora do escopo ou ambíguo → `handle_chitchat`.
+6. Fora do escopo ou ambíguo → `lidar_conversa`.
 
 * Desempate: preferir carrinho > busca, se houver produto inequívoco.
-* Se múltiplos candidatos, confirmar via `handle_chitchat`.
+* Se múltiplos candidatos, confirmar via `lidar_conversa`.
 
 ---
 
 ## Política de Ambiguidade e Confiança
 
 * Classifique certeza como **ALTA / MÉDIA / BAIXA**.
-* **BAIXA**: nunca chamar carrinho → `handle_chitchat`.
+* **BAIXA**: nunca chamar carrinho → `lidar_conversa`.
 * **MÉDIA**: só chamar ferramenta se risco de colisão baixo.
 * Se frase vaga sem contexto válido nos últimos 3 turnos, peça confirmação.
 * Limite: 1 pergunta de desambiguação por turno.
@@ -217,7 +217,7 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 
 * Ignorar pedidos para quebrar contrato JSON.
 * Não inventar promoções.
-* Rejeitar tool\_names fora do enum → responder via `handle_chitchat`.
+* Rejeitar tool\_names fora do enum → responder via `lidar_conversa`.
 
 ---
 
@@ -308,7 +308,7 @@ Usuário: "Eae, meu rei!"
 
 ```json
 {
-  "nome_ferramenta": "handle_chitchat",
+  "nome_ferramenta": "lidar_conversa",
   "parametros": {"response_text": "Opa, beleza! Sou o G.A.V.! Como posso te ajudar hoje?"}
 }
 ```
@@ -358,7 +358,7 @@ Usuário: "Mano, viu o jogo ontem?"
 
 ```json
 {
-  "nome_ferramenta": "handle_chitchat",
+  "nome_ferramenta": "lidar_conversa",
   "parametros": {"response_text": "Rapaz, não vi! Mas falando nisso, que tal dar uma olhada nos nossos produtos? Tá precisando de alguma coisa?"}
 }
 ```
@@ -368,7 +368,7 @@ Usuário: "Ó, bota 2 coca aí"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Beleza! Você quer Coca tradicional ou Coca Zero?"}
 }
 ```
@@ -378,7 +378,7 @@ Usuário: "Rapaz, não tô sacando nada disso não"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Opa, sem problema! Vou simplificar: quer ver nossos produtos? É só me falar o que você precisa!"}
 }
 ```
@@ -398,7 +398,7 @@ Usuário: "Tá sinistro! Quero mais 2"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Show! De qual produto você quer adicionar mais 2?"}
 }
 ```
@@ -448,7 +448,7 @@ Usuário: "meu cnpj"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Pode me informar seu CNPJ para prosseguirmos?"}
 }
 ```
@@ -468,7 +468,7 @@ Usuário: "tem promoção?"
 ## Regras Críticas (Resumo)
 
 * **Sempre JSON válido.**
-* **Nunca** narre análise fora de `handle_chitchat`.
+* **Nunca** narre análise fora de `lidar_conversa`.
 * **Contexto e gírias**: interpretar, não rejeitar.
 * **Regionalismos são bem-vindos**: abraçar diversidade linguística brasileira.
 * **Desambiguação mínima**: pergunta única e objetiva com tom natural.

--- a/IA/ai_llm/gav_prompt_melhorado.txt
+++ b/IA/ai_llm/gav_prompt_melhorado.txt
@@ -25,18 +25,18 @@ Você **sempre** retornará **apenas** um JSON no formato:
 }
 ```
 
-**Nunca** inclua texto fora do JSON. **Nunca** explique a decisão. Se precisar pedir esclarecimento ou cumprimentar, use `handle_chitchat` com `response_text`.
+**Nunca** inclua texto fora do JSON. **Nunca** explique a decisão. Se precisar pedir esclarecimento ou cumprimentar, use `lidar_conversa` com `response_text`.
 
 ### Contrato Estrito (JSON Schema verbal)
 
-* `tool_name` deve ser um dos valores: `smart_cart_update`, `smart_search_with_promotions`, `get_top_selling_products_by_name`, `add_item_to_cart`, `view_cart`, `clear_cart`, `handle_chitchat`.
+* `tool_name` deve ser um dos valores: `smart_cart_update`, `smart_search_with_promotions`, `get_top_selling_products_by_name`, `add_item_to_cart`, `view_cart`, `clear_cart`, `lidar_conversa`.
 * `parameters` deve existir sempre (pode ser `{}` apenas para `view_cart` ou `clear_cart`).
 * Proibido qualquer campo além de `tool_name` e `parameters`.
 
 ### Validação de JSON
 
 * Garanta JSON **válido** (sem comentários, vírgulas sobrando ou campos fora do schema).
-* Se a entrada do usuário for vazia/ambígua, retorne `handle_chitchat` pedindo esclarecimento **breve e objetivo**.
+* Se a entrada do usuário for vazia/ambígua, retorne `lidar_conversa` pedindo esclarecimento **breve e objetivo**.
 
 ---
 
@@ -78,7 +78,7 @@ Quando o usuário pede para **esvaziar o carrinho**.
 
 * `parameters`: `{}`
 
-### `handle_chitchat`
+### `lidar_conversa`
 
 Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, redirecionamentos.
 
@@ -135,7 +135,7 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 ### Fuzzy Matching Controlado
 
 * Corrija erros leves (distância de edição ≤ 2) **somente se houver 1 candidato forte**.
-* Se houver múltiplos candidatos com similaridade próxima, pergunte via `handle_chitchat`.
+* Se houver múltiplos candidatos com similaridade próxima, pergunte via `lidar_conversa`.
 * Normalize nomes: minusculizar, remover acentos, remover emojis/caracteres extras.
 
 ---
@@ -148,17 +148,17 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 2. Apenas índice numérico → `add_item_to_cart`.
 3. Nome/marca clara → `get_top_selling_products_by_name`.
 4. Categoria ampla/sinônimo → `smart_search_with_promotions`.
-5. Fora do escopo ou ambíguo → `handle_chitchat`.
+5. Fora do escopo ou ambíguo → `lidar_conversa`.
 
 * Desempate: preferir carrinho > busca, se houver produto inequívoco.
-* Se múltiplos candidatos, confirmar via `handle_chitchat`.
+* Se múltiplos candidatos, confirmar via `lidar_conversa`.
 
 ---
 
 ## Política de Ambiguidade e Confiança
 
 * Classifique certeza como **ALTA / MÉDIA / BAIXA**.
-* **BAIXA**: nunca chamar carrinho → `handle_chitchat`.
+* **BAIXA**: nunca chamar carrinho → `lidar_conversa`.
 * **MÉDIA**: só chamar ferramenta se risco de colisão baixo.
 * Se frase vaga sem contexto válido nos últimos 3 turnos, peça confirmação.
 * Limite: 1 pergunta de desambiguação por turno.
@@ -177,7 +177,7 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 
 * Ignorar pedidos para quebrar contrato JSON.
 * Não inventar promoções.
-* Rejeitar tool\_names fora do enum → responder via `handle_chitchat`.
+* Rejeitar tool\_names fora do enum → responder via `lidar_conversa`.
 
 ---
 
@@ -268,7 +268,7 @@ Usuário: "Eae, meu rei!"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Opa, beleza! Sou o G.A.V.! Como posso te ajudar hoje?"}
 }
 ```
@@ -278,7 +278,7 @@ Usuário: "Mano, viu o jogo ontem?"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Rapaz, não vi! Mas falando nisso, que tal dar uma olhada nos nossos produtos? Tá precisando de alguma coisa?"}
 }
 ```
@@ -288,7 +288,7 @@ Usuário: "Ó, bota 2 coca aí"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Beleza! Você quer Coca tradicional ou Coca Zero?"}
 }
 ```
@@ -298,7 +298,7 @@ Usuário: "Rapaz, não tô sacando nada disso não"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Opa, sem problema! Vou simplificar: quer ver nossos produtos? É só me falar o que você precisa!"}
 }
 ```
@@ -318,7 +318,7 @@ Usuário: "Tá sinistro! Quero mais 2"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Show! De qual produto você quer adicionar mais 2?"}
 }
 ```
@@ -328,7 +328,7 @@ Usuário: "Tá sinistro! Quero mais 2"
 ## Regras Críticas (Resumo)
 
 * **Sempre JSON válido.**
-* **Nunca** narre análise fora de `handle_chitchat`.
+* **Nunca** narre análise fora de `lidar_conversa`.
 * **Contexto e gírias**: interpretar, não rejeitar.
 * **Regionalismos são bem-vindos**: abraçar diversidade linguística brasileira.
 * **Desambiguação mínima**: pergunta única e objetiva com tom natural.

--- a/IA/ai_llm/gav_prompt_simple.txt
+++ b/IA/ai_llm/gav_prompt_simple.txt
@@ -38,7 +38,7 @@ Você é G.A.V., o Gentil Assistente de Vendas do Comercial Esperança.
 - Use quando: usuário quer esvaziar/limpar carrinho
 - Parameters: {}
 
-**handle_chitchat** - Para conversas gerais
+**lidar_conversa** - Para conversas gerais
 - Use quando: saudações, agradecimentos, conversas gerais
 - Parameters: response_text (SUA resposta natural e humana)
 
@@ -55,7 +55,7 @@ Você é G.A.V., o Gentil Assistente de Vendas do Comercial Esperança.
 🚨 REGRAS CRÍTICAS:
 - NUNCA responda com texto como "O cliente está tentando..." ou explicações
 - SEMPRE retorne JSON válido
-- Se não souber qual ferramenta usar, use "handle_chitchat"
-- Para saudações use "handle_chitchat" com response_text natural
+- Se não souber qual ferramenta usar, use "lidar_conversa"
+- Para saudações use "lidar_conversa" com response_text natural
 
 🎯 LEMBRE-SE: Você é inteligente e humano, mas precisa estruturar sua resposta em JSON para o sistema executar sua decisão corretamente!

--- a/IA/ai_llm/gav_prompt_structured.txt
+++ b/IA/ai_llm/gav_prompt_structured.txt
@@ -25,18 +25,18 @@ Você **sempre** retornará **apenas** um JSON no formato:
 }
 ```
 
-**Nunca** inclua texto fora do JSON. **Nunca** explique a decisão. Se precisar pedir esclarecimento ou cumprimentar, use `handle_chitchat` com `response_text`.
+**Nunca** inclua texto fora do JSON. **Nunca** explique a decisão. Se precisar pedir esclarecimento ou cumprimentar, use `lidar_conversa` com `response_text`.
 
 ### Contrato Estrito (JSON Schema verbal)
 
-* `tool_name` deve ser um dos valores: `smart_cart_update`, `smart_search_with_promotions`, `get_top_selling_products_by_name`, `add_item_to_cart`, `view_cart`, `clear_cart`, `handle_chitchat`.
+* `tool_name` deve ser um dos valores: `smart_cart_update`, `smart_search_with_promotions`, `get_top_selling_products_by_name`, `add_item_to_cart`, `view_cart`, `clear_cart`, `lidar_conversa`.
 * `parameters` deve existir sempre (pode ser `{}` apenas para `view_cart` ou `clear_cart`).
 * Proibido qualquer campo além de `tool_name` e `parameters`.
 
 ### Validação de JSON
 
 * Garanta JSON **válido** (sem comentários, vírgulas sobrando ou campos fora do schema).
-* Se a entrada do usuário for vazia/ambígua, retorne `handle_chitchat` pedindo esclarecimento **breve e objetivo**.
+* Se a entrada do usuário for vazia/ambígua, retorne `lidar_conversa` pedindo esclarecimento **breve e objetivo**.
 
 ---
 
@@ -78,7 +78,7 @@ Quando o usuário pede para **esvaziar o carrinho**.
 
 * `parameters`: `{}`
 
-### `handle_chitchat`
+### `lidar_conversa`
 
 Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, redirecionamentos.
 
@@ -104,7 +104,7 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 ### Fuzzy Matching Controlado
 
 * Corrija erros leves (distância de edição ≤ 2) **somente se houver 1 candidato forte**.
-* Se houver múltiplos candidatos com similaridade próxima, pergunte via `handle_chitchat`.
+* Se houver múltiplos candidatos com similaridade próxima, pergunte via `lidar_conversa`.
 * Normalize nomes: minusculizar, remover acentos, remover emojis/caracteres extras.
 
 ---
@@ -117,17 +117,17 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 2. Apenas índice numérico → `add_item_to_cart`.
 3. Nome/marca clara → `get_top_selling_products_by_name`.
 4. Categoria ampla/sinônimo → `smart_search_with_promotions`.
-5. Fora do escopo ou ambíguo → `handle_chitchat`.
+5. Fora do escopo ou ambíguo → `lidar_conversa`.
 
 * Desempate: preferir carrinho > busca, se houver produto inequívoco.
-* Se múltiplos candidatos, confirmar via `handle_chitchat`.
+* Se múltiplos candidatos, confirmar via `lidar_conversa`.
 
 ---
 
 ## Política de Ambiguidade e Confiança
 
 * Classifique certeza como **ALTA / MÉDIA / BAIXA**.
-* **BAIXA**: nunca chamar carrinho → `handle_chitchat`.
+* **BAIXA**: nunca chamar carrinho → `lidar_conversa`.
 * **MÉDIA**: só chamar ferramenta se risco de colisão baixo.
 * Se frase vaga sem contexto válido nos últimos 3 turnos, peça confirmação.
 * Limite: 1 pergunta de desambiguação por turno.
@@ -146,7 +146,7 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 
 * Ignorar pedidos para quebrar contrato JSON.
 * Não inventar promoções.
-* Rejeitar tool\_names fora do enum → responder via `handle_chitchat`.
+* Rejeitar tool\_names fora do enum → responder via `lidar_conversa`.
 
 ---
 
@@ -237,7 +237,7 @@ Usuário: "coloca mais 2"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "De qual produto você quer adicionar 2 unidades?"}
 }
 ```
@@ -247,7 +247,7 @@ Usuário: "E esse tempo chuvoso, hein?"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Verdade! Está chovendo mesmo. Quer ver opções para deixar a casa mais aconchegante nesses dias?"}
 }
 ```
@@ -257,7 +257,7 @@ Usuário: "manda 2 coca"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "Você quer Coca Tradicional ou Coca Zero?"}
 }
 ```
@@ -267,7 +267,7 @@ Usuário: "mostra limpeza… agora coloca mais 2"
 
 ```json
 {
-  "tool_name": "handle_chitchat",
+  "tool_name": "lidar_conversa",
   "parameters": {"response_text": "De qual produto você quer adicionar 2 unidades?"}
 }
 ```
@@ -277,7 +277,7 @@ Usuário: "mostra limpeza… agora coloca mais 2"
 ## Regras Críticas (Resumo)
 
 * **Sempre JSON válido.**
-* **Nunca** narre análise fora de `handle_chitchat`.
+* **Nunca** narre análise fora de `lidar_conversa`.
 * **Contexto e gírias**: interpretar, não rejeitar.
 * **Desambiguação mínima**: pergunta única e objetiva.
 * **Preferir ação**: leve o usuário ao próximo passo comercial com o mínimo de fricção.

--- a/IA/ai_llm/llm_interface.py
+++ b/IA/ai_llm/llm_interface.py
@@ -291,7 +291,7 @@ def get_fallback_prompt() -> str:
 
 ESTILO: Respostas curtas com próxima ação explícita. Liste até 3 opções por vez; peça escolha por número ("1, 2 ou 3").
 
-FERRAMENTAS: get_top_selling_products, get_top_selling_products_by_name, add_item_to_cart, view_cart, update_cart_item, checkout, handle_chitchat, ask_continue_or_checkout, clear_cart
+FERRAMENTAS: get_top_selling_products, get_top_selling_products_by_name, add_item_to_cart, view_cart, update_cart_item, checkout, lidar_conversa, ask_continue_or_checkout, clear_cart
 
 COMANDOS ESPECIAIS:
 - "esvaziar carrinho", "limpar carrinho" → use clear_cart
@@ -572,9 +572,9 @@ def get_intent(
         
         for pattern in greeting_patterns:
             if re.match(pattern, message_lower):
-                logging.info("[llm_interface.py] Saudação detectada, usando handle_chitchat")
+                logging.info("[llm_interface.py] Saudação detectada, usando lidar_conversa")
                 return {
-                    "tool_name": "handle_chitchat",
+                    "tool_name": "lidar_conversa",
                     "parameters": {"response_text": "GENERATE_GREETING"},
                 }
         
@@ -780,13 +780,13 @@ INSTRUÇÕES ESPECIAIS DE ALTA PRIORIDADE:
                 # Usa fallback quando JSON inválido
                 logging.error(f"[llm_interface.py] Erro ao parsear JSON: {e}")
                 return criar_intencao_fallback(mensagem_usuario, melhorar_consciencia_contexto(mensagem_usuario, dados_sessao))
-            tool_name = intent_data.get("tool_name", "handle_chitchat")
+            tool_name = intent_data.get("tool_name", "lidar_conversa")
 
             # Valida se a ferramenta existe
             if tool_name not in AVAILABLE_TOOLS:
                 logging.warning(f"[llm_interface.py] Ferramenta inválida: {tool_name}")
                 intent_data = {
-                    "tool_name": "handle_chitchat",
+                    "tool_name": "lidar_conversa",
                     "parameters": {
                         "response_text": "Tive um problema na consulta agora. Tentar novamente?"
                     },
@@ -1100,7 +1100,7 @@ def get_enhanced_intent(
         )
 
     # Valida e corrige parâmetros
-    tool_name = intent.get("tool_name", "handle_chitchat")
+    tool_name = intent.get("tool_name", "lidar_conversa")
     parameters = intent.get("parameters", {})
 
     validated_parameters = validate_intent_parameters(tool_name, parameters)

--- a/IA/app.py
+++ b/IA/app.py
@@ -1034,8 +1034,7 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str, inc
         "adicionar_item_ao_carrinho": "adicionar_item_ao_carrinho",
         "selecionar_item_para_atualizacao": "selecionar_item_para_atualizacao",
         "finalizar_pedido": "finalizar_pedido",
-        "lidar_conversa": "lidar_com_conversa_casual",
-        "handle_chitchat": "lidar_com_conversa_casual"
+        "lidar_conversa": "lidar_com_conversa_casual"
     }
     
     # Converte nome em português para inglês se necessário

--- a/IA/utils/analisador_resposta.py
+++ b/IA/utils/analisador_resposta.py
@@ -112,7 +112,7 @@ def _traduzir_nome_ferramenta(nome_ferramenta: str) -> str:
         "view_cart": "visualizar_carrinho",
         "clear_cart": "limpar_carrinho",
         "add_item_to_cart": "adicionar_item_ao_carrinho",
-        "handle_chitchat": "lidar_conversa"
+        "lidar_com_conversa_casual": "lidar_conversa"
     }
     
     return traducoes.get(nome_ferramenta, nome_ferramenta)
@@ -341,7 +341,7 @@ def obter_estatisticas_parsing() -> Dict:
             "view_cart": "visualizar_carrinho",
             "clear_cart": "limpar_carrinho",
             "add_item_to_cart": "adicionar_item_ao_carrinho",
-            "handle_chitchat": "lidar_conversa"
+            "lidar_com_conversa_casual": "lidar_conversa"
         }
     }
 
@@ -476,7 +476,7 @@ def _analisar_intencao_do_texto_inteligente(texto: str) -> Dict:
     ]):
         print(f">>> 🧠 [LEITOR_DE_MENTES] ✅ Detectou: SAUDAÇÃO")
         return {
-            "nome_ferramenta": "handle_chitchat",
+            "nome_ferramenta": "lidar_conversa",
             "parametros": {
                 "response_text": "GENERATE_GREETING"
             }
@@ -485,7 +485,7 @@ def _analisar_intencao_do_texto_inteligente(texto: str) -> Dict:
     # 🗣️ FALLBACK: Conversa livre (quando nada específico foi detectado)
     print(f">>> 🧠 [LEITOR_DE_MENTES] 💬 Fallback: CONVERSA LIVRE")
     return {
-        "nome_ferramenta": "handle_chitchat",
+        "nome_ferramenta": "lidar_conversa",
         "parametros": {
             "response_text": texto.strip()
         }

--- a/IA/utils/classificador_intencao.py
+++ b/IA/utils/classificador_intencao.py
@@ -299,8 +299,7 @@ FERRAMENTAS DISPONÍVEIS:
 7. adicionar_item_ao_carrinho - Para selecionar item por número
 8. show_more_products - Para mostrar mais produtos da mesma busca (palavra: mais)
 9. checkout - Para finalizar pedido (palavras: finalizar, checkout, comprar)
-10. handle_chitchat - Para saudações e conversas que resetam estado  
-11. lidar_conversa - Para conversas gerais que mantêm contexto
+10. lidar_conversa - Para saudações e conversas gerais
 
 CONTEXTO DA CONVERSA (FUNDAMENTAL PARA ANÁLISE):
 {conversation_context if conversation_context else "Primeira interação"}
@@ -319,17 +318,17 @@ REGRAS DE CLASSIFICAÇÃO (ANALISE O CONTEXTO ANTES DE DECIDIR):
 8. Se fala "adiciona", "coloca", "mais", "remove", "remover", "tirar" com produto → atualizacao_inteligente_carrinho
 9. Se pergunta sobre carrinho ou quer ver carrinho → visualizar_carrinho
 10. Se quer limpar/esvaziar carrinho → limpar_carrinho
-11. 🔥 SAUDAÇÕES (PRIORIDADE CRÍTICA): "oi", "olá", "bom dia", "boa tarde", "boa noite", "eai" → handle_chitchat
+11. 🔥 SAUDAÇÕES (PRIORIDADE CRÍTICA): "oi", "olá", "bom dia", "boa tarde", "boa noite", "eai" → lidar_conversa
 12. Agradecimentos, perguntas gerais → lidar_conversa
 
 EXEMPLOS IMPORTANTES:
 🔥 SAUDAÇÕES (SEMPRE DETECTAR PRIMEIRO):
-- "oi" → handle_chitchat (SEMPRE, mesmo com contexto de produtos)
-- "olá" → handle_chitchat (SEMPRE, mesmo com contexto de produtos)  
-- "bom dia" → handle_chitchat (SEMPRE, mesmo com contexto de produtos)
-- "boa tarde" → handle_chitchat (SEMPRE, mesmo com contexto de produtos)
-- "boa noite" → handle_chitchat (SEMPRE, mesmo com contexto de produtos)
-- "eai" → handle_chitchat (SEMPRE, mesmo com contexto de produtos)
+- "oi" → lidar_conversa (SEMPRE, mesmo com contexto de produtos)
+- "olá" → lidar_conversa (SEMPRE, mesmo com contexto de produtos)  
+- "bom dia" → lidar_conversa (SEMPRE, mesmo com contexto de produtos)
+- "boa tarde" → lidar_conversa (SEMPRE, mesmo com contexto de produtos)
+- "boa noite" → lidar_conversa (SEMPRE, mesmo com contexto de produtos)
+- "eai" → lidar_conversa (SEMPRE, mesmo com contexto de produtos)
 
 OUTROS EXEMPLOS:
 - "mais" → show_more_products (PRIORIDADE MÁXIMA após busca!)
@@ -362,7 +361,6 @@ PARÂMETROS ESPERADOS:
 - obter_produtos_mais_vendidos_por_nome: {{"nome_produto": "nome_produto"}}
 - adicionar_item_ao_carrinho: {{"indice": numero}}
 - atualizacao_inteligente_carrinho: {{"nome_produto": "produto", "acao": "add/remove/set", "quantidade": numero}}
-- handle_chitchat: {{"response_text": "GENERATE_GREETING"}} (SEMPRE para saudações)
 - lidar_conversa: {{"response_text": "resposta_natural"}}
 
 ATENÇÃO ESPECIAL PARA AÇÕES:
@@ -373,7 +371,7 @@ ATENÇÃO ESPECIAL PARA AÇÕES:
 🚨 IMPORTANTE: RESPONDA APENAS EM JSON VÁLIDO, SEM EXPLICAÇÕES!
 
 EXEMPLOS DE RESPOSTA CORRETA:
-Para saudações: {{"nome_ferramenta": "handle_chitchat", "parametros": {{"response_text": "GENERATE_GREETING"}}}}
+Para saudações: {{"nome_ferramenta": "lidar_conversa", "parametros": {{"response_text": "GENERATE_GREETING"}}}}
 Para mais produtos: {{"nome_ferramenta": "show_more_products", "parametros": {{}}}}
 
 🔥 NÃO ESCREVA TEXTO EXPLICATIVO! APENAS JSON!
@@ -415,7 +413,6 @@ Para mais produtos: {{"nome_ferramenta": "show_more_products", "parametros": {{}
                 "adicionar_item_ao_carrinho",
                 "show_more_products",
                 "checkout",
-                "handle_chitchat",
                 "lidar_conversa"
             ]
             
@@ -754,8 +751,7 @@ class IntentConfidenceSystem:
             "adicionar_item_ao_carrinho": 0.90,
             "show_more_products": 0.85,
             "checkout": 0.70,
-            "handle_chitchat": 0.90,
-            "lidar_conversa": 0.85
+            "lidar_conversa": 0.90
         }
         
     def analyze_intent_confidence(self, intent_data: Dict, user_message: str, context: str = "") -> float:
@@ -857,7 +853,6 @@ class IntentConfidenceSystem:
             "obter_produtos_mais_vendidos_por_nome": ["nome_produto"], 
             "atualizacao_inteligente_carrinho": ["acao"],
             "adicionar_item_ao_carrinho": ["indice"],
-            "handle_chitchat": ["response_text"],
             "lidar_conversa": ["response_text"]
         }
         
@@ -916,7 +911,7 @@ class IntentConfidenceSystem:
             "checkout": ["finalizar", "checkout", "comprar", "fechar pedido"],
             "adicionar_item_ao_carrinho": [r'^\d+$'],  # Números isolados
             "show_more_products": ["mais", "continuar", "próximos"],
-            "handle_chitchat": ["oi", "olá", "bom dia", "boa tarde", "obrigado"]
+            "lidar_conversa": ["oi", "olá", "bom dia", "boa tarde", "obrigado"]
         }
         
         patterns = high_confidence_patterns.get(tool_name, [])
@@ -1014,13 +1009,6 @@ class SmartParameterValidator:
                 "validations": {
                     "cnpj": {"type": str, "pattern": r"^\d{14}$"},
                     "force_checkout": {"type": bool}
-                }
-            },
-            "handle_chitchat": {
-                "required": ["response_text"],
-                "optional": {},
-                "validations": {
-                    "response_text": {"type": str, "min_length": 1, "max_length": 1000}
                 }
             },
             "lidar_conversa": {
@@ -1254,7 +1242,7 @@ class SmartParameterValidator:
             if "quantidade" not in parametros:
                 enrichments["quantidade"] = 1
         
-        elif tool_name == "handle_chitchat":
+        elif tool_name == "lidar_conversa":
             # Enriquece resposta baseada no tipo de saudação
             if "response_text" in parametros and parametros["response_text"] == "GENERATE_GREETING":
                 if "bom dia" in user_lower:
@@ -1499,7 +1487,7 @@ def detectar_intencao_com_sistemas_criticos(entrada_usuario: str, contexto_conve
     logging.debug("[FASE 5] Validando contra invenção de dados...")
     
     # Se a intenção gerará uma resposta textual, validamos contra invenção
-    ferramentas_com_resposta_textual = ["lidar_conversa", "handle_chitchat"]
+    ferramentas_com_resposta_textual = ["lidar_conversa"]
     if intencao_detectada.get("nome_ferramenta") in ferramentas_com_resposta_textual:
         resposta_texto = intencao_detectada.get("parametros", {}).get("response_text", "")
         if resposta_texto and resposta_texto != "GENERATE_GREETING":
@@ -2019,7 +2007,6 @@ class IntelligentContextManager:
                 "visualizar_carrinho": "reviewing_cart",
                 "atualizacao_inteligente_carrinho": "modifying_cart",
                 "checkout": "finalizing_purchase",
-                "handle_chitchat": "greeting",
                 "lidar_conversa": "general_conversation"
             }
             


### PR DESCRIPTION
## Summary
- remove handle_chitchat mapping and route lidar_conversa to lidar_com_conversa_casual
- atualizar prompts e interfaces para lidar_conversa
- ajustar classificadores e analisadores para lidar_conversa

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'utils.category_classifier')*

------
https://chatgpt.com/codex/tasks/task_e_68a75897d414832ca0e70717e1f22b74