### PR TITLE
Renomeia ações de carrinho para português

### DIFF
--- a/IA/ai_llm/gav_prompt.txt
+++ b/IA/ai_llm/gav_prompt.txt
@@ -388,7 +388,7 @@ Usuário: "Põe meia dúzia de cerveja"
 
 ```json
 {
-  "tool_name": "smart_cart_update",
+  "tool_name": "atualizacao_inteligente_carrinho",
   "parameters": {"product_name": "cerveja", "action": "add", "quantity": 6}
 }
 ```

--- a/IA/ai_llm/gav_prompt_melhorado.txt
+++ b/IA/ai_llm/gav_prompt_melhorado.txt
@@ -29,8 +29,8 @@ Você **sempre** retornará **apenas** um JSON no formato:
 
 ### Contrato Estrito (JSON Schema verbal)
 
-* `tool_name` deve ser um dos valores: `smart_cart_update`, `smart_search_with_promotions`, `get_top_selling_products_by_name`, `add_item_to_cart`, `view_cart`, `clear_cart`, `handle_chitchat`.
-* `parameters` deve existir sempre (pode ser `{}` apenas para `view_cart` ou `clear_cart`).
+* `tool_name` deve ser um dos valores: `atualizacao_inteligente_carrinho`, `smart_search_with_promotions`, `get_top_selling_products_by_name`, `adicionar_item_ao_carrinho`, `visualizar_carrinho`, `limpar_carrinho`, `handle_chitchat`.
+* `parameters` deve existir sempre (pode ser `{}` apenas para `visualizar_carrinho` ou `limpar_carrinho`).
 * Proibido qualquer campo além de `tool_name` e `parameters`.
 
 ### Validação de JSON
@@ -42,7 +42,7 @@ Você **sempre** retornará **apenas** um JSON no formato:
 
 ## Ferramentas Disponíveis
 
-### `smart_cart_update`
+### `atualizacao_inteligente_carrinho`
 
 Quando o usuário deseja **modificar quantidade** de um produto: adicionar, definir total, remover.
 
@@ -60,19 +60,19 @@ Quando o usuário pede **produto específico** por nome/marca/modelo.
 
 * `parameters`: `product_name`
 
-### `add_item_to_cart`
+### `adicionar_item_ao_carrinho`
 
 Quando o usuário escolhe **índice numérico** de uma lista previamente exibida.
 
 * `parameters`: `index`
 
-### `view_cart`
+### `visualizar_carrinho`
 
 Quando o usuário pede para **ver o carrinho**.
 
 * `parameters`: `{}`
 
-### `clear_cart`
+### `limpar_carrinho`
 
 Quando o usuário pede para **esvaziar o carrinho**.
 
@@ -144,8 +144,8 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 
 ### Critérios Determinísticos (empate → desempate)
 
-1. Verbos de quantidade + número explícito ou implícito → `smart_cart_update`.
-2. Apenas índice numérico → `add_item_to_cart`.
+1. Verbos de quantidade + número explícito ou implícito → `atualizacao_inteligente_carrinho`.
+2. Apenas índice numérico → `adicionar_item_ao_carrinho`.
 3. Nome/marca clara → `get_top_selling_products_by_name`.
 4. Categoria ampla/sinônimo → `smart_search_with_promotions`.
 5. Fora do escopo ou ambíguo → `handle_chitchat`.
@@ -188,7 +188,7 @@ Usuário: "Eita, bora de mais uma daquela Skol, meu!"
 
 ```json
 {
-  "tool_name": "smart_cart_update",
+  "tool_name": "atualizacao_inteligente_carrinho",
   "parameters": {"product_name": "skol", "action": "add", "quantity": 1}
 }
 ```
@@ -218,7 +218,7 @@ Usuário: "Ó, muda o arroz pra 5 unidade"
 
 ```json
 {
-  "tool_name": "smart_cart_update",
+  "tool_name": "atualizacao_inteligente_carrinho",
   "parameters": {"product_name": "arroz", "action": "set", "quantity": 5}
 }
 ```
@@ -228,7 +228,7 @@ Usuário: "Corta 2 coca cola fora"
 
 ```json
 {
-  "tool_name": "smart_cart_update",
+  "tool_name": "atualizacao_inteligente_carrinho",
   "parameters": {"product_name": "coca-cola", "action": "remove", "quantity": 2}
 }
 ```
@@ -238,7 +238,7 @@ Usuário: "Oxe, como tá meu carrinho?"
 
 ```json
 {
-  "tool_name": "view_cart",
+  "tool_name": "visualizar_carrinho",
   "parameters": {}
 }
 ```
@@ -248,7 +248,7 @@ Usuário: "Eita, apaga tudo aí"
 
 ```json
 {
-  "tool_name": "clear_cart",
+  "tool_name": "limpar_carrinho",
   "parameters": {}
 }
 ```
@@ -258,7 +258,7 @@ Usuário: "Manda o 3 mesmo"
 
 ```json
 {
-  "tool_name": "add_item_to_cart",
+  "tool_name": "adicionar_item_ao_carrinho",
   "parameters": {"index": 3}
 }
 ```
@@ -308,7 +308,7 @@ Usuário: "Põe meia dúzia de cerveja"
 
 ```json
 {
-  "tool_name": "smart_cart_update",
+  "tool_name": "atualizacao_inteligente_carrinho",
   "parameters": {"product_name": "cerveja", "action": "add", "quantity": 6}
 }
 ```

--- a/IA/ai_llm/gav_prompt_simple.txt
+++ b/IA/ai_llm/gav_prompt_simple.txt
@@ -22,19 +22,19 @@ Você é G.A.V., o Gentil Assistente de Vendas do Comercial Esperança.
 - Use quando: busca por produto específico com marca/detalhes
 - Parameters: product_name
 
-**smart_cart_update** - Para modificar carrinho
+**atualizacao_inteligente_carrinho** - Para modificar carrinho
 - Use quando: adicionar/remover/alterar quantidade de produtos
 - Parameters: product_name, action (add/set/remove), quantity
 
-**add_item_to_cart** - Para selecionar item por número
+**adicionar_item_ao_carrinho** - Para selecionar item por número
 - Use quando: usuário digita apenas um número
 - Parameters: index
 
-**view_cart** - Para ver carrinho
+**visualizar_carrinho** - Para ver carrinho
 - Use quando: usuário quer ver o que tem no carrinho
 - Parameters: {}
 
-**clear_cart** - Para limpar carrinho
+**limpar_carrinho** - Para limpar carrinho
 - Use quando: usuário quer esvaziar/limpar carrinho
 - Parameters: {}
 

--- a/IA/ai_llm/gav_prompt_structured.txt
+++ b/IA/ai_llm/gav_prompt_structured.txt
@@ -29,8 +29,8 @@ Você **sempre** retornará **apenas** um JSON no formato:
 
 ### Contrato Estrito (JSON Schema verbal)
 
-* `tool_name` deve ser um dos valores: `smart_cart_update`, `smart_search_with_promotions`, `get_top_selling_products_by_name`, `add_item_to_cart`, `view_cart`, `clear_cart`, `handle_chitchat`.
-* `parameters` deve existir sempre (pode ser `{}` apenas para `view_cart` ou `clear_cart`).
+* `tool_name` deve ser um dos valores: `atualizacao_inteligente_carrinho`, `smart_search_with_promotions`, `get_top_selling_products_by_name`, `adicionar_item_ao_carrinho`, `visualizar_carrinho`, `limpar_carrinho`, `handle_chitchat`.
+* `parameters` deve existir sempre (pode ser `{}` apenas para `visualizar_carrinho` ou `limpar_carrinho`).
 * Proibido qualquer campo além de `tool_name` e `parameters`.
 
 ### Validação de JSON
@@ -42,7 +42,7 @@ Você **sempre** retornará **apenas** um JSON no formato:
 
 ## Ferramentas Disponíveis
 
-### `smart_cart_update`
+### `atualizacao_inteligente_carrinho`
 
 Quando o usuário deseja **modificar quantidade** de um produto: adicionar, definir total, remover.
 
@@ -60,19 +60,19 @@ Quando o usuário pede **produto específico** por nome/marca/modelo.
 
 * `parameters`: `product_name`
 
-### `add_item_to_cart`
+### `adicionar_item_ao_carrinho`
 
 Quando o usuário escolhe **índice numérico** de uma lista previamente exibida.
 
 * `parameters`: `index`
 
-### `view_cart`
+### `visualizar_carrinho`
 
 Quando o usuário pede para **ver o carrinho**.
 
 * `parameters`: `{}`
 
-### `clear_cart`
+### `limpar_carrinho`
 
 Quando o usuário pede para **esvaziar o carrinho**.
 
@@ -113,8 +113,8 @@ Saudações, dúvidas gerais, pedidos de esclarecimento, confirmações curtas, 
 
 ### Critérios Determinísticos (empate → desempate)
 
-1. Verbos de quantidade + número explícito ou implícito → `smart_cart_update`.
-2. Apenas índice numérico → `add_item_to_cart`.
+1. Verbos de quantidade + número explícito ou implícito → `atualizacao_inteligente_carrinho`.
+2. Apenas índice numérico → `adicionar_item_ao_carrinho`.
 3. Nome/marca clara → `get_top_selling_products_by_name`.
 4. Categoria ampla/sinônimo → `smart_search_with_promotions`.
 5. Fora do escopo ou ambíguo → `handle_chitchat`.
@@ -157,7 +157,7 @@ Usuário: "Bora de mais um daquela cerveja Skol"
 
 ```json
 {
-  "tool_name": "smart_cart_update",
+  "tool_name": "atualizacao_inteligente_carrinho",
   "parameters": {"product_name": "cerveja skol", "action": "add", "quantity": 1}
 }
 ```
@@ -187,7 +187,7 @@ Usuário: "muda a quantidade de arroz pra 5"
 
 ```json
 {
-  "tool_name": "smart_cart_update",
+  "tool_name": "atualizacao_inteligente_carrinho",
   "parameters": {"product_name": "arroz", "action": "set", "quantity": 5}
 }
 ```
@@ -197,7 +197,7 @@ Usuário: "tira 2 coca cola"
 
 ```json
 {
-  "tool_name": "smart_cart_update",
+  "tool_name": "atualizacao_inteligente_carrinho",
   "parameters": {"product_name": "coca-cola", "action": "remove", "quantity": 2}
 }
 ```
@@ -207,7 +207,7 @@ Usuário: "meu carrinho"
 
 ```json
 {
-  "tool_name": "view_cart",
+  "tool_name": "visualizar_carrinho",
   "parameters": {}
 }
 ```
@@ -217,7 +217,7 @@ Usuário: "esvaziar tudo"
 
 ```json
 {
-  "tool_name": "clear_cart",
+  "tool_name": "limpar_carrinho",
   "parameters": {}
 }
 ```
@@ -227,7 +227,7 @@ Usuário: "pego o 3"
 
 ```json
 {
-  "tool_name": "add_item_to_cart",
+  "tool_name": "adicionar_item_ao_carrinho",
   "parameters": {"index": 3}
 }
 ```

--- a/IA/ai_llm/llm_interface.py
+++ b/IA/ai_llm/llm_interface.py
@@ -291,10 +291,10 @@ def get_fallback_prompt() -> str:
 
 ESTILO: Respostas curtas com próxima ação explícita. Liste até 3 opções por vez; peça escolha por número ("1, 2 ou 3").
 
-FERRAMENTAS: get_top_selling_products, get_top_selling_products_by_name, add_item_to_cart, view_cart, update_cart_item, checkout, handle_chitchat, ask_continue_or_checkout, clear_cart
+FERRAMENTAS: get_top_selling_products, get_top_selling_products_by_name, adicionar_item_ao_carrinho, visualizar_carrinho, update_cart_item, checkout, handle_chitchat, ask_continue_or_checkout, limpar_carrinho
 
 COMANDOS ESPECIAIS:
-- "esvaziar carrinho", "limpar carrinho" → use clear_cart
+- "esvaziar carrinho", "limpar carrinho" → use limpar_carrinho
 - CNPJ (14 dígitos) quando solicitado → use find_customer_by_cnpj
 
 SEMPRE RESPONDA EM JSON VÁLIDO COM tool_name E parameters!"""
@@ -383,7 +383,7 @@ def melhorar_consciencia_contexto(mensagem_usuario: str, dados_sessao: Dict) -> 
     }
 
     # 🆕 DETECTA COMANDOS DE LIMPEZA DE CARRINHO
-    context["clear_cart_command"] = detect_cart_clearing_intent(mensagem_usuario)
+    context["limpar_carrinho_command"] = detect_cart_clearing_intent(mensagem_usuario)
     
     # 🆕 DETECTA CONTEXTO DE CHECKOUT/FINALIZAÇÃO
     checkout_context = detect_checkout_context(dados_sessao)
@@ -555,9 +555,9 @@ def get_intent(
             }
         
         # 🆕 PRIORIDADE ALTA: Comandos de limpeza de carrinho
-        if enhanced_context.get("clear_cart_command"):
+        if enhanced_context.get("limpar_carrinho_command"):
             logging.info("[llm_interface.py] Comando de limpeza de carrinho detectado")
-            return {"tool_name": "clear_cart", "parameters": {}}
+            return {"tool_name": "limpar_carrinho", "parameters": {}}
 
         # Para mensagens simples, usa detecção rápida sem IA
         message_lower = mensagem_usuario.lower().strip()
@@ -658,8 +658,8 @@ def get_intent(
 
         # 🆕 CONSTRÓI CONTEXTO ESPECÍFICO PARA PROBLEMAS IDENTIFICADOS
         special_context = ""
-        if enhanced_context.get("clear_cart_command"):
-            special_context += "⚠️ COMANDO DE LIMPEZA DE CARRINHO DETECTADO - Use clear_cart\n"
+        if enhanced_context.get("limpar_carrinho_command"):
+            special_context += "⚠️ COMANDO DE LIMPEZA DE CARRINHO DETECTADO - Use limpar_carrinho\n"
         if enhanced_context.get("is_cnpj_in_checkout_context"):
             special_context += "⚠️ CNPJ VÁLIDO EM CONTEXTO DE CHECKOUT - Use find_customer_by_cnpj\n"
         if enhanced_context.get("awaiting_cnpj"):
@@ -693,7 +693,7 @@ ANÁLISE CONTEXTUAL:
 - Quantidade inferida: {enhanced_context.get('inferred_quantity', 'Não especificada')}
 - É CNPJ válido: {'Sim' if enhanced_context.get('is_valid_cnpj') else 'Não'}
 - CNPJ em contexto checkout: {'Sim' if enhanced_context.get('is_cnpj_in_checkout_context') else 'Não'}
-- Comando limpar carrinho: {'Sim' if enhanced_context.get('clear_cart_command') else 'Não'}
+- Comando limpar carrinho: {'Sim' if enhanced_context.get('limpar_carrinho_command') else 'Não'}
 
 COMANDOS DETECTADOS:
 - Ver carrinho: {'Sim' if enhanced_context.get('direct_cart_command') else 'Não'}
@@ -701,10 +701,10 @@ COMANDOS DETECTADOS:
 - Continuar: {'Sim' if enhanced_context.get('continue_shopping') else 'Não'}
 
 INSTRUÇÕES ESPECIAIS DE ALTA PRIORIDADE:
-1. ⚠️ Se "Comando limpar carrinho: Sim", SEMPRE use clear_cart
+1. ⚠️ Se "Comando limpar carrinho: Sim", SEMPRE use limpar_carrinho
 2. ⚠️ Se "CNPJ em contexto checkout: Sim", SEMPRE use find_customer_by_cnpj
 3. ⚠️ Se "Esperando CNPJ: Sim" e mensagem parece CNPJ, use find_customer_by_cnpj
-4. Se há produtos mostrados e usuário digitou número, use add_item_to_cart
+4. Se há produtos mostrados e usuário digitou número, use adicionar_item_ao_carrinho
 5. Considere TODO o histórico da conversa para interpretar a intenção
 """
 
@@ -797,7 +797,7 @@ INSTRUÇÕES ESPECIAIS DE ALTA PRIORIDADE:
 
             # Se é seleção numérica e temos produtos, adiciona quantidade se detectada
             if (
-                tool_name == "add_item_to_cart"
+                tool_name == "adicionar_item_ao_carrinho"
                 and enhanced_context.get("numeric_selection")
                 and enhanced_context.get("inferred_quantity")
             ):
@@ -1038,7 +1038,7 @@ def validate_intent_parameters(tool_name: str, parameters: Dict) -> Dict:
     """Valida e corrige parâmetros da intenção conforme a ferramenta."""
     logging.debug(f"Validando parâmetros da intenção para a ferramenta: '{tool_name}', Parâmetros: {parameters}")
 
-    if tool_name == "add_item_to_cart":
+    if tool_name == "adicionar_item_ao_carrinho":
         # Garante que codprod seja inteiro e qt seja número válido
         if "codprod" in parameters:
             try:

--- a/IA/app.py
+++ b/IA/app.py
@@ -716,7 +716,7 @@ def _handle_pending_action(
 
     elif pending_action == "AWAITING_SMART_UPDATE_SELECTION":
         print(">>> CONSOLE: CHEGOU NO ELIF AWAITING_SMART_UPDATE_SELECTION")
-        # 🆕 Tratamento para seleção em smart_cart_update
+        # 🆕 Tratamento para seleção em atualizacao_inteligente_carrinho
         print(">>> CONSOLE: Tratando ação pendente AWAITING_SMART_UPDATE_SELECTION")
         print(f">>> CONSOLE: Mensagem recebida: '{incoming_msg}'")
         try:
@@ -1027,8 +1027,8 @@ def _route_tool(session: Dict, state: Dict, intent: Dict, sender_phone: str, inc
     # Mapeamento de nomes em português para inglês (para compatibilidade)
     nome_para_ingles = {
         "busca_inteligente_com_promocoes": "smart_search_with_promotions",
-        "obter_produtos_mais_vendidos_por_nome": "obter_produtos_mais_vendidos_by_name",
-        "atualizacao_inteligente_carrinho": "smart_cart_update",
+        "obter_produtos_mais_vendidos_por_nome": "obter_produtos_mais_vendidos_por_nome",
+        "atualizacao_inteligente_carrinho": "atualizacao_inteligente_carrinho",
         "visualizar_carrinho": "visualizar_carrinho",
         "limpar_carrinho": "limpar_carrinho",
         "adicionar_item_ao_carrinho": "adicionar_item_ao_carrinho",
@@ -2229,7 +2229,7 @@ RESPONDA APENAS com a categoria do banco (CERVEJA, DOCES, DETERGENTE, HIGIENE, e
             })
             pending_action = None
 
-    elif tool_name == "smart_cart_update":
+    elif tool_name == "atualizacao_inteligente_carrinho":
         # 🆕 NOVA FERRAMENTA: Atualização inteligente do carrinho
         product_name = parameters.get("product_name", "").strip()
         action = parameters.get("action", "add")  # "add", "set", "remove"

--- a/IA/utils/analisador_resposta.py
+++ b/IA/utils/analisador_resposta.py
@@ -108,10 +108,10 @@ def _traduzir_nome_ferramenta(nome_ferramenta: str) -> str:
     traducoes = {
         "smart_search_with_promotions": "busca_inteligente_com_promocoes",
         "get_top_selling_products_by_name": "obter_produtos_mais_vendidos_por_nome",
-        "smart_cart_update": "atualizacao_inteligente_carrinho",
-        "view_cart": "visualizar_carrinho",
-        "clear_cart": "limpar_carrinho",
-        "add_item_to_cart": "adicionar_item_ao_carrinho",
+        "atualizacao_inteligente_carrinho": "atualizacao_inteligente_carrinho",
+        "visualizar_carrinho": "visualizar_carrinho",
+        "limpar_carrinho": "limpar_carrinho",
+        "adicionar_item_ao_carrinho": "adicionar_item_ao_carrinho",
         "handle_chitchat": "lidar_conversa"
     }
     
@@ -337,10 +337,10 @@ def obter_estatisticas_parsing() -> Dict:
         "traducao_ferramentas": {
             "smart_search_with_promotions": "busca_inteligente_com_promocoes",
             "get_top_selling_products_by_name": "obter_produtos_mais_vendidos_por_nome",
-            "smart_cart_update": "atualizacao_inteligente_carrinho",
-            "view_cart": "visualizar_carrinho",
-            "clear_cart": "limpar_carrinho",
-            "add_item_to_cart": "adicionar_item_ao_carrinho",
+            "atualizacao_inteligente_carrinho": "atualizacao_inteligente_carrinho",
+            "visualizar_carrinho": "visualizar_carrinho",
+            "limpar_carrinho": "limpar_carrinho",
+            "adicionar_item_ao_carrinho": "adicionar_item_ao_carrinho",
             "handle_chitchat": "lidar_conversa"
         }
     }
@@ -391,7 +391,7 @@ def _analisar_intencao_do_texto_inteligente(texto: str) -> Dict:
     ]):
         print(f">>> 🧠 [LEITOR_DE_MENTES] ✅ Detectou: LIMPAR CARRINHO")
         return {
-            "nome_ferramenta": "clear_cart", 
+            "nome_ferramenta": "limpar_carrinho", 
             "parametros": {}
         }
     
@@ -401,7 +401,7 @@ def _analisar_intencao_do_texto_inteligente(texto: str) -> Dict:
     ]):
         print(f">>> 🧠 [LEITOR_DE_MENTES] ✅ Detectou: VER CARRINHO")
         return {
-            "nome_ferramenta": "view_cart",
+            "nome_ferramenta": "visualizar_carrinho",
             "parametros": {}
         }
     
@@ -424,7 +424,7 @@ def _analisar_intencao_do_texto_inteligente(texto: str) -> Dict:
         numero = int(numeros_texto[0])
         print(f">>> 🧠 [LEITOR_DE_MENTES] ✅ Detectou: ADICIONAR PRODUTO #{numero}")
         return {
-            "nome_ferramenta": "add_item_to_cart",
+            "nome_ferramenta": "adicionar_item_ao_carrinho",
             "parametros": {"index": numero}
         }
     
@@ -466,7 +466,7 @@ def _analisar_intencao_do_texto_inteligente(texto: str) -> Dict:
     ]):
         print(f">>> 🧠 [LEITOR_DE_MENTES] ✅ Detectou: ATUALIZAR CARRINHO")
         return {
-            "nome_ferramenta": "smart_cart_update",
+            "nome_ferramenta": "atualizacao_inteligente_carrinho",
             "parametros": {}
         }
     

--- a/IA/utils/detector_intencao_avancado.py
+++ b/IA/utils/detector_intencao_avancado.py
@@ -63,8 +63,8 @@ INTENÇÕES POSSÍVEIS:
 - remove_item: Remover produto específico
 - update_quantity: Alterar quantidade
 - replace_item: Substituir um produto por outro
-- clear_cart: Limpar carrinho completo
-- view_cart: Ver conteúdo do carrinho
+- limpar_carrinho: Limpar carrinho completo
+- visualizar_carrinho: Ver conteúdo do carrinho
 - unknown: Não relacionado ao carrinho
 
 EXEMPLOS:
@@ -72,7 +72,7 @@ EXEMPLOS:
 - "coloca mais duas" → add_item (quantidade: 2)
 - "troca por heineken" → replace_item
 - "deixa só uma de cada" → update_quantity
-- "quero mudar tudo" → clear_cart
+- "quero mudar tudo" → limpar_carrinho
 - "aumenta pra 5" → update_quantity
 - "remove o item 2" → remove_item (índice: 2)
 


### PR DESCRIPTION
## Summary
- renomeia funções de carrinho para `adicionar_item_ao_carrinho`, `visualizar_carrinho`, `limpar_carrinho` e `atualizacao_inteligente_carrinho`
- ajusta prompts e mapeamentos para novos nomes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.category_classifier')*

------
https://chatgpt.com/codex/tasks/task_e_68a758994db4832caa43fc026538d442