### PR TITLE
Renomear checkout para finalizar_pedido

### DIFF
--- a/IA/utils/analisador_resposta.py
+++ b/IA/utils/analisador_resposta.py
@@ -428,13 +428,13 @@ def _analisar_intencao_do_texto_inteligente(texto: str) -> Dict:
             "parametros": {"index": numero}
         }
     
-    # 5. 💰 CHECKOUT/FINALIZAR
+    # 5. 💰 FINALIZAR PEDIDO
     if any(phrase in texto_lower for phrase in [
-        "finalizar", "checkout", "concluir compra", "fechar pedido"
+        "finalizar", "finalizar pedido", "concluir compra", "fechar pedido"
     ]):
-        print(f">>> 🧠 [LEITOR_DE_MENTES] ✅ Detectou: CHECKOUT")
+        print(f">>> 🧠 [LEITOR_DE_MENTES] ✅ Detectou: FINALIZAR_PEDIDO")
         return {
-            "nome_ferramenta": "checkout",
+            "nome_ferramenta": "finalizar_pedido",
             "parametros": {}
         }
     

--- a/IA/utils/controlador_fluxo_conversa.py
+++ b/IA/utils/controlador_fluxo_conversa.py
@@ -97,7 +97,7 @@ class ControladorFluxoConversa:
         contexto_lower = contexto.lower()
         
         # NOVA LÓGICA: Análise mais precisa baseada em evidências reais
-        if "checkout" in contexto_lower or "finalizar pedido" in contexto_lower:
+        if "finalizar_pedido" in contexto_lower or "finalizar pedido" in contexto_lower:
             return EstadoConversa.PROCESSO_CHECKOUT
         elif "quantas unidades" in contexto_lower and "produto" in contexto_lower:
             return EstadoConversa.SELECAO_QUANTIDADE
@@ -207,7 +207,7 @@ class ControladorFluxoConversa:
                 "esperado": [r'^\d+$', r'\d+\s*unidades?', r'\d+\s*un'],
                 "inesperado": ['carrinho', 'produtos', 'buscar', 'olá']
             },
-            "checkout": {
+            "finalizar_pedido": {
                 "esperado": ['sim', 'não', 'confirmar', 'finalizar', 'cancelar'],
                 "inesperado": ['produtos', 'buscar', 'cerveja', 'adicionar']
             }
@@ -219,8 +219,8 @@ class ControladorFluxoConversa:
             tipo_contexto = "listagem_produtos"
         elif any(frase in contexto_lower for frase in ["quantas unidades", "quantidade"]):
             tipo_contexto = "selecao_quantidade"
-        elif any(frase in contexto_lower for frase in ["finalizar", "checkout", "confirmar"]):
-            tipo_contexto = "checkout"
+        elif any(frase in contexto_lower for frase in ["finalizar", "finalizar_pedido", "confirmar"]):
+            tipo_contexto = "finalizar_pedido"
         
         resultado = {"valido": True, "confianca": 0.8, "problemas": []}
         
@@ -355,7 +355,7 @@ class ControladorFluxoConversa:
         palavras_chave_topicos = {
             "produtos": ["produto", "item", "cerveja", "refrigerante", "limpeza"],
             "carrinho": ["carrinho", "itens", "pedido"],
-            "checkout": ["finalizar", "checkout", "pagamento"],
+            "finalizar_pedido": ["finalizar", "finalizar_pedido", "pagamento"],
             "busca": ["busca", "procurar", "encontrar"],
             "quantidade": ["quantidade", "unidades", "quantos"]
         }
@@ -373,7 +373,7 @@ class ControladorFluxoConversa:
         palavras_chave_topicos = {
             "produtos": ["cerveja", "refrigerante", "produto", "biscoito", "doce", "limpeza"],
             "carrinho": ["carrinho", "meu carrinho", "pedido"],
-            "checkout": ["finalizar", "comprar", "fechar"],
+            "finalizar_pedido": ["finalizar", "comprar", "fechar"],
             "busca": ["quero", "procuro", "busco"],
             "saudacao": ["oi", "olá", "bom dia", "boa tarde"]
         }

--- a/test_confidence_system.py
+++ b/test_confidence_system.py
@@ -337,7 +337,7 @@ def testar_gestao_inteligente_contexto():
         memoria_trabalho = update_working_memory(
             dados_sessao_teste,
             "finalizar",
-            {"nome_ferramenta": "checkout", "parametros": {}}
+            {"nome_ferramenta": "finalizar_pedido", "parametros": {}}
         )
         
         print(f"   Estado da conversa: {memoria_trabalho.get('conversation_state', 'unknown')}")
@@ -378,13 +378,13 @@ def testar_gestao_inteligente_contexto():
         
         # Teste identificação de tarefas pendentes
         tarefas_pendentes = context_manager._identify_incomplete_tasks_ia(
-            dados_sessao_teste, {"nome_ferramenta": "checkout"}
+            dados_sessao_teste, {"nome_ferramenta": "finalizar_pedido"}
         )
         print(f"   Tarefas pendentes identificadas: {len(tarefas_pendentes)}")
         
         # Teste determinação de estado
         estado_atual = context_manager._determine_current_state_ia(
-            dados_sessao_teste, "finalizar", {"nome_ferramenta": "checkout"}
+            dados_sessao_teste, "finalizar", {"nome_ferramenta": "finalizar_pedido"}
         )
         print(f"   Estado atual determinado: {estado_atual}")
         


### PR DESCRIPTION
## Summary
- atualiza controlador de fluxo para verificar `finalizar_pedido`
- substitui ferramenta `checkout` por `finalizar_pedido` e ajusta palavras-chave
- renomeia análise de resposta e testes para `finalizar_pedido`

## Testing
- `pytest test_confidence_system.py -q`
- `pytest -q` *(falhou: ModuleNotFoundError: No module named 'utils.category_classifier')*


------
https://chatgpt.com/codex/tasks/task_e_68a758986f80832ca5fb19c95cb6c112