### PR TITLE
Avoid duplicate responses in session history

### DIFF
--- a/IA/app.py
+++ b/IA/app.py
@@ -2559,9 +2559,8 @@ def _finalize_session(
     if response_text:
         # 📝 SEMPRE salva a resposta no histórico antes de tentar enviar 
         # 🆕 EVITA DUPLICAÇÃO: Só salva se não for idêntica à última mensagem
-        history = session.get("conversation_history", [])
-        last_msg = history[-1] if history else {}
-        if not (last_msg.get("role") == "assistant" and last_msg.get("message") == response_text):
+        historico = session.get("historico_conversa", [])
+        if not (historico and historico[-1].get("message") == response_text):
             adicionar_mensagem_historico(session, "assistant", response_text, "BOT_RESPONSE")
     
     salvar_sessao(session_id, session)


### PR DESCRIPTION
## Summary
- Use `historico_conversa` key instead of `conversation_history`
- Check last history entry to prevent duplicate assistant responses

## Testing
- `PYTHONPATH=IA pytest` *(fails: No module named 'utils.category_classifier')*
- Manual search/navigation simulation to ensure single entry per response

------
https://chatgpt.com/codex/tasks/task_e_68a7745f9e98832c9ab1377d21ef0238