### PR TITLE
Orientação ao usuário em seleções vazias

### DIFF
--- a/IA/utils/redirecionamento_inteligente.py
+++ b/IA/utils/redirecionamento_inteligente.py
@@ -629,17 +629,34 @@ def detectar_usuario_confuso(entrada_atual: str, contexto_conversa: str,
         entrada_atual, contexto_conversa, historico_conversa
     )
 
+
+
 def registrar_sucesso_guidance():
-    """
-    Registra que uma orientação foi bem-sucedida.
-    """
+    """Registra que uma orientação foi bem-sucedida."""
     _redirecionador_inteligente.registrar_sucesso_redirecionamento()
 
+
 def obter_estatisticas_redirecionamento() -> Dict:
-    """
-    Retorna estatísticas do sistema de redirecionamento.
-    
-    Returns:
-        Dict: Estatísticas de detecção e redirecionamento
-    """
+    """Retorna estatísticas do sistema de redirecionamento."""
     return _redirecionador_inteligente.obter_estatisticas_redirecionamento()
+
+
+def verificar_entrada_vazia_selecao(entrada_atual: str, last_bot_action: Optional[str]) -> Optional[str]:
+    """Detecta quando usuário envia entrada vazia ou '?' durante uma etapa de seleção.
+
+    Args:
+        entrada_atual: Texto enviado pelo usuário.
+        last_bot_action: Última ação do bot registrada na sessão.
+
+    Returns:
+        Mensagem de orientação se a condição for atendida, caso contrário ``None``.
+    """
+    acoes_selecao = {
+        'AWAITING_PRODUCT_SELECTION',
+        'AWAITING_MENU_SELECTION',
+        'AWAITING_CORRECTION_SELECTION',
+    }
+
+    if last_bot_action in acoes_selecao and entrada_atual.strip() in ('', '?'):
+        return "Digite o número do item ou 'ajuda' para ver opções"
+    return None

--- a/IA/utils/test_redirecionamento_inteligente.py
+++ b/IA/utils/test_redirecionamento_inteligente.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Testes para redirecionamento quando usuário envia '?' em seleção."""
+
+import unittest
+import sys
+from pathlib import Path
+
+# Adiciona diretório IA ao path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from utils.classificador_intencao import detectar_intencao_com_sistemas_criticos
+
+
+class TestRedirecionamentoAjuda(unittest.TestCase):
+    """Verifica se '?' aciona mensagem de ajuda durante seleção."""
+
+    def test_question_mark_triggers_help(self):
+        dados_sessao = {"messages": [], "last_bot_action": "AWAITING_PRODUCT_SELECTION"}
+        resultado = detectar_intencao_com_sistemas_criticos(
+            entrada_usuario="?",
+            contexto_conversa="Produtos:\n1. Item A\n2. Item B\nEscolha um número:",
+            dados_sessao=dados_sessao,
+        )
+        self.assertEqual(
+            resultado["parametros"]["response_text"],
+            "Digite o número do item ou 'ajuda' para ver opções",
+        )
+        self.assertTrue(resultado["necessita_redirecionamento"])
+        self.assertEqual(resultado["tipo_resposta"], "redirecionamento_guidance")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Detect empty or '?' inputs when awaiting a selection and guide the user to choose a number or request help
- Short-circuit intent detection to avoid unnecessary searches
- Add regression test ensuring '?' triggers help prompt

## Testing
- `pytest IA/utils/test_redirecionamento_inteligente.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.category_classifier')*

------
https://chatgpt.com/codex/tasks/task_e_68a77465360c832cb2068789d1a945e5