### PR TITLE
Reconhece consulta 'produtos' como pedido de produtos populares

### DIFF
--- a/IA/utils/analisador_resposta.py
+++ b/IA/utils/analisador_resposta.py
@@ -453,7 +453,7 @@ def _analisar_intencao_do_texto_inteligente(texto: str) -> Dict:
     if any(phrase in texto_lower for phrase in [
         "produtos populares", "mais vendidos", "top produtos",
         "popular products", "best sellers"
-    ]):
+    ]) or re.fullmatch(r"\s*produtos\s*[?!.]*", texto_lower):
         print(f">>> 🧠 [LEITOR_DE_MENTES] ✅ Detectou: PRODUTOS POPULARES")
         return {
             "nome_ferramenta": "get_top_selling_products",

--- a/IA/utils/test_analisador_resposta.py
+++ b/IA/utils/test_analisador_resposta.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Testes para o analisador de respostas da IA."""
+
+import sys
+from pathlib import Path
+import unittest
+
+# Adiciona diretório IA ao path para permitir importações
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from utils.analisador_resposta import extrair_json_da_resposta_ia
+
+
+class TestAnalisadorResposta(unittest.TestCase):
+    """Testes para o analisador de resposta."""
+
+    def test_detecta_produtos_populares_com_palavra_isolada(self):
+        """Deve mapear 'produtos' para produtos populares."""
+        resultado = extrair_json_da_resposta_ia("produtos")
+        self.assertEqual(resultado["nome_ferramenta"], "get_top_selling_products")
+        self.assertEqual(resultado["parametros"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Detect isolated word **"produtos"** and route to `get_top_selling_products`
- Add unit test ensuring the analyzer maps "produtos" to popular products tool

## Testing
- `pytest IA/utils/test_analisador_resposta.py`
- `pytest IA/utils/test_category_classifier.py` *(fails: ModuleNotFoundError: No module named 'utils.category_classifier')*


------
https://chatgpt.com/codex/tasks/task_e_68a7746059f8832c93cadb7f583173da