### PR TITLE
Expose confidence scores and log intent decisions

### DIFF
--- a/IA/utils/gav_logger.py
+++ b/IA/utils/gav_logger.py
@@ -10,7 +10,10 @@ import time
 import inspect
 import uuid
 import threading
-from configuracao_logs import configurar_logging_principal, obter_estatisticas_deduplicacao
+from .configuracao_logs import (
+    configurar_logging_principal,
+    obter_estatisticas_deduplicacao,
+)
 
 # Logger global configurado
 _logger_principal = None


### PR DESCRIPTION
## Summary
- Attach `confidence_score` and `confidence_below_threshold` to detected intents
- Signal low-confidence intents and log decisions with `log_decisao_ia`
- Fix logger import path for utils package

## Testing
- `python test_confidence_system.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7c3a77c08832cbf509fa84f784510